### PR TITLE
fix: prevent embedded drawings from auto-centering on re-entry

### DIFF
--- a/src/tldraw/drawing/tldraw-drawing-editor.tsx
+++ b/src/tldraw/drawing/tldraw-drawing-editor.tsx
@@ -100,7 +100,11 @@ export function TldrawDrawingEditor(props: TldrawDrawingEditorProps) {
 		})
 		
 		// view setup
-		initDrawingCamera(editor);
+		// Only call initDrawingCamera in non-embedded mode to prevent
+		// content from jumping to center when re-entering edit mode
+		if (!props.embedded) {
+			initDrawingCamera(editor);
+		}
 		if (props.embedded) {
 			editor.setCameraOptions({
 				isLocked: true,

--- a/src/utils/tldraw-helpers.ts
+++ b/src/utils/tldraw-helpers.ts
@@ -546,7 +546,7 @@ function addNewTemplateShapes(editor: Editor) {
 
 	const hasContainer = editor.store.has('shape:writing-container' as TLShapeId);
 	if(!hasContainer) {
-			editor.createShape({
+		 	editor.createShape({
 			id: 'shape:writing-container' as TLShapeId,
 			type: 'writing-container',
 		})
@@ -790,7 +790,9 @@ export const resizeWritingTemplateTightly = (editor: Editor) => {
 
 export async function getDrawingSvg(editor: Editor): Promise<svgObj | undefined> {
 	const allShapeIds = Array.from(editor.getCurrentPageShapeIds().values());
-	const svgObj = await editor.getSvgString(allShapeIds);
+	// Use viewport bounds to ensure SVG matches visible canvas area
+	const viewportBounds = editor.getViewportPageBounds();
+	const svgObj = await editor.getSvgString(allShapeIds, { bounds: viewportBounds, padding: 0 });
 	return svgObj;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where embedded drawing content jumps to the center of the canvas when re-entering edit mode from preview mode.

**The Problem:**
- User draws content at a specific position (e.g., top-left corner)
- Exits edit mode to preview
- Re-enters edit mode
- Content has jumped to the center of the canvas

**Root Cause:**
In `tldraw-drawing-editor.tsx`, `initDrawingCamera(editor)` is called unconditionally in the `handleMount` function. This function calls `zoomToBounds()` which centers all shapes within the viewport, overwriting the user's intended content position.

**The Fix:**
Skip `initDrawingCamera()` in embedded mode (`props.embedded === true`) since:
1. The canvas size is fixed by the embed dimensions
2. Users expect content to stay where they placed it
3. The camera is locked after initialization anyway
4. Auto-centering destroys intentional layout

## Changes

### `src/tldraw/drawing/tldraw-drawing-editor.tsx`
- Added conditional check to only call `initDrawingCamera(editor)` when NOT in embedded mode

### `src/utils/tldraw-helpers.ts`
- Enhanced `getDrawingSvg()` to use viewport bounds for SVG export, ensuring the preview matches the visible canvas area

## Testing

- [x] Create embedded drawing in markdown file
- [x] Draw shape in top-left corner
- [x] Exit to preview mode
- [x] Re-enter edit mode
- [x] Verify shape remains in top-left corner (not centered)
- [x] Verify standalone drawing mode still auto-centers as expected

## Related

This follows the pattern used by Writing mode, which uses `initWritingCamera()` with a fixed camera position instead of auto-centering.