### PR TITLE
Make Cmd + Z, Cmd + Shift + Z work in Ink

### DIFF
--- a/src/tldraw/drawing/tldraw-drawing-editor.tsx
+++ b/src/tldraw/drawing/tldraw-drawing-editor.tsx
@@ -1,7 +1,7 @@
 import './tldraw-drawing-editor.scss';
 import { Editor, HistoryEntry, StoreSnapshot, TLRecord, TLStoreSnapshot, TLUiOverrides, Tldraw, TldrawEditor, TldrawHandles, TldrawOptions, TldrawScribble, TldrawSelectionBackground, TldrawSelectionForeground, TldrawShapeIndicators, defaultShapeTools, defaultShapeUtils, defaultTools, getSnapshot, TLSerializedStore, TLEditorSnapshot, TLUiActionsContextType } from "@tldraw/tldraw";
 import { useRef } from "react";
-import { Activity, adaptTldrawToObsidianThemeMode, focusChildTldrawEditor, getActivityType, getDrawingSvg, initDrawingCamera, prepareDrawingSnapshot, preventTldrawCanvasesCausingObsidianGestures } from "../../utils/tldraw-helpers";
+import { Activity, adaptTldrawToObsidianThemeMode, focusChildTldrawEditor, getActivityType, getDrawingSvg, initDrawingCamera, prepareDrawingSnapshot, preventTldrawCanvasesCausingObsidianGestures, setupUndoRedoHotkeys } from "../../utils/tldraw-helpers";
 import InkPlugin from "../../main";
 import * as React from "react";
 import { svgToPngDataUri } from 'src/utils/screenshots';
@@ -156,10 +156,20 @@ export function TldrawDrawingEditor(props: TldrawDrawingEditorProps) {
 			scope: 'all'	// Filters some things like camera movement changes. But Not sure it's locked down enough, so leaving as all.
 		})
 
+		// Bind Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z for undo/redo while the canvas
+		// has focus. Uses a capture-phase listener so Obsidian's global keymap
+		// can't consume the event first.
+		const removeUndoRedoHotkeys = setupUndoRedoHotkeys(
+			editorWrapperRefEl.current,
+			() => tlEditorRef.current,
+			(ed) => queueOrRunStorePostProcesses(ed),
+		);
+
 		const unmountActions = () => {
 			// NOTE: This prevents the postProcessTimer completing when a new file is open and saving over that file.
 			resetInputPostProcessTimers();
 			removeUserActionListener();
+			removeUndoRedoHotkeys();
 		}
 
 		if(props.saveControlsReference) {

--- a/src/tldraw/writing/tldraw-writing-editor.tsx
+++ b/src/tldraw/writing/tldraw-writing-editor.tsx
@@ -1,7 +1,7 @@
 import './tldraw-writing-editor.scss';
 import { Box, Editor, HistoryEntry, StoreSnapshot, TLStoreSnapshot, TLRecord, TLShapeId, TLStore, TLUiOverrides, TLUnknownShape, Tldraw, getSnapshot, TLSerializedStore, TldrawOptions, TldrawEditor, defaultTools, defaultShapeTools, defaultShapeUtils, defaultBindingUtils, TldrawScribble, TldrawShapeIndicators, TldrawSelectionForeground, TldrawSelectionBackground, TldrawHandles, TLEditorSnapshot } from "@tldraw/tldraw";
 import { useRef } from "react";
-import { Activity, WritingCameraLimits, adaptTldrawToObsidianThemeMode, deleteObsoleteWritingTemplateShapes, focusChildTldrawEditor, getActivityType, getWritingContainerBounds, getWritingSvg, hideWritingContainer, hideWritingLines, hideWritingTemplate, initWritingCamera, initWritingCameraLimits, lockShape, prepareWritingSnapshot, preventTldrawCanvasesCausingObsidianGestures, resizeWritingTemplateInvitingly, restrictWritingCamera, silentlyChangeStore, unhideWritingContainer, unhideWritingLines, unhideWritingTemplate, unlockShape, updateWritingStoreIfNeeded, useStash } from "../../utils/tldraw-helpers";
+import { Activity, WritingCameraLimits, adaptTldrawToObsidianThemeMode, deleteObsoleteWritingTemplateShapes, focusChildTldrawEditor, getActivityType, getWritingContainerBounds, getWritingSvg, hideWritingContainer, hideWritingLines, hideWritingTemplate, initWritingCamera, initWritingCameraLimits, lockShape, prepareWritingSnapshot, preventTldrawCanvasesCausingObsidianGestures, resizeWritingTemplateInvitingly, restrictWritingCamera, setupUndoRedoHotkeys, silentlyChangeStore, unhideWritingContainer, unhideWritingLines, unhideWritingTemplate, unlockShape, updateWritingStoreIfNeeded, useStash } from "../../utils/tldraw-helpers";
 import { WritingContainer, WritingContainerUtil } from "../writing-shapes/writing-container"
 import { WritingMenu } from "../writing-menu/writing-menu";
 import InkPlugin from "../../main";
@@ -164,10 +164,20 @@ export function TldrawWritingEditor(props: TldrawWritingEditorProps) {
 			scope: 'all'	// Filters some things like camera movement changes. But Not sure it's locked down enough, so leaving as all.
 		})
 
+		// Bind Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z for undo/redo while the canvas
+		// has focus. Uses a capture-phase listener so Obsidian's global keymap
+		// can't consume the event first.
+		const removeUndoRedoHotkeys = setupUndoRedoHotkeys(
+			editorWrapperRefEl.current,
+			() => tlEditorRef.current,
+			(ed) => queueOrRunStorePostProcesses(ed),
+		);
+
 		const unmountActions = () => {
 			// NOTE: This prevents the postProcessTimer completing when a new file is open and saving over that file.
 			resetInputPostProcessTimers();
 			removeUserActionListener();
+			removeUndoRedoHotkeys();
 		}
 
 		if(props.saveControlsReference) {

--- a/src/utils/tldraw-helpers.ts
+++ b/src/utils/tldraw-helpers.ts
@@ -804,3 +804,65 @@ export function focusChildTldrawEditor(containerEl: HTMLElement | null) {
 		containerEl.find('.tl-container').focus({preventScroll: true});
 	}
 }
+
+/***
+ * Wire Cmd/Ctrl+Z (undo) and Cmd/Ctrl+Shift+Z (redo) on the Ink canvas.
+ *
+ * The listener is attached to the editor wrapper in the capture phase so
+ * Obsidian's global keymap can't swallow the event before tldraw sees it.
+ * Because it sits on the wrapper rather than document, it's naturally scoped:
+ * it only fires when focus is inside the canvas — if the user's cursor is in
+ * a regular Markdown editor, Cmd+Z still performs Obsidian's normal undo.
+ *
+ * Returns a cleanup function.
+ */
+export function setupUndoRedoHotkeys(
+	containerEl: HTMLElement | null,
+	getEditor: () => Editor | undefined,
+	onStoreChange?: (editor: Editor) => void,
+): () => void {
+	if (!containerEl) return () => { /* no-op */ };
+
+	const handler = (ev: KeyboardEvent) => {
+		// Only the modifier that owns undo/redo on this platform
+		// (Cmd on macOS/iPadOS, Ctrl elsewhere).
+		if (!(ev.metaKey || ev.ctrlKey)) return;
+		if (ev.altKey) return;
+		if (ev.isComposing) return; // Leave IME sequences alone.
+		if (ev.key.toLowerCase() !== 'z') return;
+
+		// Don't preempt native undo inside text inputs (e.g. an active tldraw
+		// text shape in edit mode, or any <input>/<textarea>/contentEditable).
+		// Those have their own per-field undo stacks that we shouldn't override.
+		const target = ev.target as HTMLElement | null;
+		if (target && isEditableElement(target)) return;
+
+		const editor = getEditor();
+		if (!editor) return;
+
+		// Own the shortcut whenever focus is in the canvas: even a no-op press
+		// shouldn't fall through to Obsidian's document-level undo.
+		ev.preventDefault();
+		ev.stopPropagation();
+
+		const isRedo = ev.shiftKey;
+		const canAct = isRedo ? editor.getCanRedo() : editor.getCanUndo();
+		if (!canAct) return;
+
+		silentlyChangeStore(editor, () => {
+			if (isRedo) editor.redo();
+			else editor.undo();
+		});
+		if (onStoreChange) onStoreChange(editor);
+	};
+
+	containerEl.addEventListener('keydown', handler, { capture: true });
+	return () => containerEl.removeEventListener('keydown', handler, { capture: true });
+}
+
+function isEditableElement(el: HTMLElement): boolean {
+	const tag = el.tagName;
+	if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+	if (el.isContentEditable) return true;
+	return false;
+}


### PR DESCRIPTION
This change adds support for the default Undo/Redo keyboard shortcut to Ink’s editor.

By binding Cmd + Z and Cmd + Shift + Z to the native `editor.undo()`, `editor.redo()`, the user can seamlessly Undo or Redo in Ink as they would anywhere else in Obsidian (or their system for that matter). This a small but noticeable quality of life improvement when you’re at a keyboard.

A personal note: having the toolbar button be the only way to undo changes made what was otherwise my favourite way to draw in Obsidian feel unusable. This was a shame, since Ink is exactly what drawing in Obsidian *should be* and. No other plugin comes close to its native feel.

## Why Cmd + Z, Cmd + Shift + Z wasn’t already working

The toolbar buttons in `modify-menu.tsx` [already call into the tldraw](https://github.com/daledesilva/obsidian_ink/blob/07251dd/src/tldraw/modify-menu/modify-menu.tsx#L49-L65). TLDraw *does* come with its own Cmd + Z handler, but inside Obsidian the global keymap consumes the event before tldraw’s document-level listener fires, so the keystroke never reaches the canvas.

## How this adds support for the default shortcut

Attached to `setupUndoRedoHotkeys`—a small helper in `src/utils/tldraw-helpers.ts`—is a **capture-phase** `keydown`. Capture phase beats Obsidian’s handler: scoping to the wrapper (rather than `document`) means it **only fires when focus is inside the Ink canvas**. Cmd/Ctrl (+ Shift) + Z outside the Ink canvas is *unaffected*—it continues to work normally in the regular Markdown editor.

Since the handler reuses `silentlyChangeStore` and the `queueOrRunStorePostProcesses` callback, the save/post-process pipeline is the exact same as when the toolbar buttons are used; and **behaviour on the buttons themselves is unchanged*.

## Safeguards

- **Editable targets are excluded.** If the event’s target is a `<input>`, `<textarea>`, or `contentEditable` element (e.g. a tldraw text shape in edit mode), the handler bails out so the field’s native per-input undo stack keeps working.
- **IME-safe.** `ev.isComposing` is checked so undo doesn’t hijack a composing keystroke.
- **No-op guarded.** `getCanUndo()` / `getCanRedo()` are checked before firing, so an empty stack doesn’t trigger a spurious save.
- **Cleanup on unmount.** Returns a remover, called from each editor’s `unmountActions`.

## Platform support

- **macOS, Windows, Linux**: Cmd/Ctrl + Z and Cmd/Ctrl + Shift + Z works flawlessly in both writing and drawing embeds. This uses `event.key` rather than `event.code`, meaning it’s keyboard-layout-agnostic (AZERTY, Dvorak, what have you).
- **iOS / iPadOS with a hardware keyboard** (limitation): does *not* work through the DOM listener. The Obsidian mobile app (shared codebase between iOS and iPadOS) registers `UIKeyCommand` bindings at the UIKit level, so Cmd + Z is consumed by Obsidian’s native handler before the event ever reaches the WKWebView DOM. I’ve confirmed this on iPhone; iPadOS is untested on hardware but has the same architecture, so the same limitation almost certainly applies. For mobile the right fix routes through `addCommand` rather than DOM events, which I have prepared as a follow-up PR.
- **Touch/stylus without a keyboard**: moot—no keydown events fire at all, so the listener is inert and the toolbar undo/redo buttons remain the primary affordance. Behaviour is thus unchanged.

## Changes: very minimal

3 files, +85/-3. No new dependencies, no config surface, no change to existing behaviour for anyone not using the shortcut.

## Additional notes: Relationship to #155

I noticed #155 (still open) also adds Cmd/Ctrl + Z for the drawing view, bundled alongside Space-pan, Z-zoom, and a PNG export utility. This PR is intentionally scoped narrowly to just the keyboard shortcut—and extends it to the writing editor as well, which #155 doesn’t touch. The handler is extracted as a reusable helper (`setupUndoRedoHotkeys`) so either approach can coexist or be reused.