### PR TITLE
fix: use vault.read() + data URI to avoid CORS errors on Electron 39+ / Obsidian 2.x

### DIFF
--- a/docs/embed-preview-svg-loading.md
+++ b/docs/embed-preview-svg-loading.md
@@ -1,0 +1,58 @@
+# Embed preview SVG loading
+
+## Why it exists
+
+Locked writing and drawing embeds show the vault SVG through `react-inlinesvg`. An earlier path used `vault.getResourcePath()` so InlineSVG could fetch an `app://…` URL. On installs that run Obsidian against **system Electron 39.8.10+** (common on Arch, CachyOS, Nixpkgs), that fetch fails CORS: the page origin is `app://obsidian.md` while the file URL is a different `app://` host. Locked Live Preview and Reading mode then show an empty placeholder even though edit mode still works (editors use `vault.read()`, not HTTP).
+
+Embed previews therefore load SVG **through Obsidian’s vault API** and pass **raw markup** into InlineSVG so nothing is fetched over the network.
+
+## Conceptual understanding
+
+- **Edit mode** already reads the file with `vault.read()` and never hits CORS.
+- **Locked preview** must also avoid XHR/`fetch` of `app://` resource URLs.
+- `react-inlinesvg` treats a `src` that contains `<svg` as **inline content** (no request). Data URIs also avoid CORS, but writing previews treat any `data:` `src` as an `<img>`, which breaks theme CSS that targets inlined paths.
+
+```mermaid
+flowchart TD
+    Lock["Embed locks / preview mounts"]
+    Read["vault.read embedded SVG file"]
+    Raw["setFileSrc raw SVG markup"]
+    Inline["react-inlinesvg inlines SVG markup in-process"]
+    Theme["ink-svg-preview-theme.scss restyles paths"]
+    Lock --> Read --> Raw --> Inline --> Theme
+```
+
+## Flows
+
+1. Preview mounts (Live Preview lock or Reading mode host).
+2. `refreshSrc()` calls `vault.read` on the embedded `TFile`.
+3. On success it sets React state to the SVG string (not a resource URL, not a data URI).
+4. Writing and drawing previews render `<SVG src={fileSrc} />` (`react-inlinesvg`).
+5. InlineSVG inlines the markup; shared theme CSS can recolour strokes.
+6. Vault `modify` on that path runs `refreshSrc()` again so returning from edit updates the locked view.
+
+## Technical details
+
+| Piece | Location / behaviour |
+|-------|----------------------|
+| Drawing preview | `drawing-embed-preview.tsx` → `refreshSrc()` |
+| Writing preview | `writing-embed-preview.tsx` → `refreshSrc()` |
+| Why not `getResourcePath` | Resource URLs are fetched by InlineSVG and fail under Electron custom-protocol CORS |
+| Why not data URI | Writing’s `isImg = fileSrc.startsWith('data')` would switch to `<img>` and skip path theming |
+| InlineSVG branch | Library uses `src.includes('<svg')` for in-process content (same idea as the empty writing SVG import) |
+
+Related surfaces that also prefer vault string + inline DOM (not this React path): SVG picker and native SVG leaf via `mountInlineSvgPreview` — see [Ink colours and theming](ink-colours-and-theming.md).
+
+## Technical gotchas
+
+1. **Do not restore `getResourcePath` + InlineSVG fetch** — It regresses blank locked previews on system Electron 39.8.10+ even when the official Obsidian AppImage still works.
+2. **Do not feed writing previews a `data:` URI** — Writing still branches on `data` → `<img>`; that undoes dark-theme path fills under `.ddc_ink_writing-embed-preview`.
+3. **Raw markup must include `<svg`** — InlineSVG only skips fetch when that substring is present; other strings are treated as URLs again.
+4. **Async read races** — `refreshSrc` does not cancel in-flight reads; rapid modify/unmount can briefly apply a stale string. Prefer vault read over resource URLs anyway; add cancellation only if a race shows up in practice.
+5. **Official Electron upgrades** — Upstream Obsidian may eventually CORS-enable `app://`. Keep the vault-read path anyway: it matches edit mode and keeps theming reliable.
+
+## See also
+
+- [Ink colours and theming](ink-colours-and-theming.md) — Why previews must stay inlined SVG
+- [Reading mode](reading-mode.md) — Reading mode mounts the same locked preview components
+- [Reading mode embed rendering](reading-mode-embed-rendering.md) — Post-processor that hosts those previews

--- a/docs/ink-colours-and-theming.md
+++ b/docs/ink-colours-and-theming.md
@@ -68,7 +68,7 @@ The file on disk stays black and gray. The preview overrides those for display o
 
 ### Displaying in Live Preview or Reading mode
 
-1. Ink loads the SVG into the preview area as inline SVG.
+1. Ink loads the SVG with `vault.read` and passes **raw markup** into the embed preview (see [Embed preview SVG loading](embed-preview-svg-loading.md)) — not an `app://` resource URL and not a data URI.
 2. Theme CSS sets stroke and fill from Obsidian variables.
 3. Guide lines pick up the writing-line colour; pen paths pick up text colour.
 4. You change theme → variables change → preview colours change immediately.
@@ -123,7 +123,7 @@ Ink must **inline** the SVG for theme CSS to reach individual paths and lines. A
 
 | Surface | Entry | Mount helper | Theme host classes |
 |---------|-------|--------------|--------------------|
-| Note embeds | Embed preview components | `mountInlineSvgPreview` (or equivalent inline path) | `ddc_ink_writing-embed-preview` / `ddc_ink_drawing-embed-preview` |
+| Note embeds | Embed preview `refreshSrc` → `react-inlinesvg` | Raw SVG string from `vault.read` (see [Embed preview SVG loading](embed-preview-svg-loading.md)) | `ddc_ink_writing-embed-preview` / `ddc_ink_drawing-embed-preview` |
 | SVG picker | `svg-picker-modal.ts` | `mountInlineSvgPreview` | Same embed preview classes |
 | Native SVG leaf | `ensureThemedNativeInkSvgView` (writing/drawing registers) | `mountInlineSvgPreview` | `ddc_ink_svg-native-view-preview` **plus** the matching embed preview class |
 
@@ -131,7 +131,7 @@ Native-leaf layout (sizing, scroll, centered media) lives in `src/logic/utils/sv
 
 ## Technical gotchas
 
-1. **Image tags do not theme** — Reading mode, the native SVG leaf, and any other `img`/`object` path must swap to (or hide behind) an inlined SVG preview for proper `--text-normal` theming. Dark mode temporarily inverts native Ink `img` markers as a readability fallback until (or unless) the inline host mounts — do not invert the React preview hosts.
+1. **Image tags do not theme** — Reading mode, the native SVG leaf, and any other `img`/`object` path must swap to (or hide behind) an inlined SVG preview for proper `--text-normal` theming. Dark mode temporarily inverts native Ink `img` markers as a readability fallback until (or unless) the inline host mounts — do not invert the React preview hosts. Writing embed previews also treat `data:` `src` as `<img>` — keep locked writing on raw SVG markup for InlineSVG ([Embed preview SVG loading](embed-preview-svg-loading.md)).
 2. **Baked black wins without CSS** — SVG `fill="#000000"` on a path is strong. Preview CSS uses `!important` so theme colour can override it inside Ink previews.
 3. **Reuse embed host classes on the native leaf** — Native-view layout uses `ddc_ink_svg-native-view-preview`; colour comes from the same writing/drawing embed classes. Do not invent a parallel stroke-colour stylesheet for dedicated native views.
 4. **Hide native media before `vault.read`** — Ink marks the leaf with `ddc_ink_svg-view--awaiting-theme` synchronously on open so Obsidian’s `img`/`object` never paints baked-black strokes during the async read. Removing that early suppress brings back a dark-mode flash.
@@ -143,6 +143,7 @@ Native-leaf layout (sizing, scroll, centered media) lives in `src/logic/utils/sv
 
 ## See also
 
+- [Embed preview SVG loading](embed-preview-svg-loading.md) — Why locked previews use `vault.read` + raw SVG
 - [Reading mode](reading-mode.md) — How Reading mode loads and shows embed previews
 - [Reading mode embed rendering](reading-mode-embed-rendering.md) — Reading mode implementation
 - [Plugin memory and persistence](plugin-memory-and-persistence.md) — What lives in vault files vs settings

--- a/docs/reading-mode-embed-rendering.md
+++ b/docs/reading-mode-embed-rendering.md
@@ -136,6 +136,7 @@ PDF export often requires rules under `@media print { .print … }`. Frontmatter
 ## See also
 
 - [Reading mode](reading-mode.md) — Conceptual overview (non-technical)
+- [Embed preview SVG loading](embed-preview-svg-loading.md) — Locked preview `vault.read` + raw SVG (CORS / theming)
 - [Ink colours and theming](ink-colours-and-theming.md) — How preview colours follow the theme
 - [Ink embeds: contexts and limitations](ink-embeds-contexts-and-limitations.md)
 - [UX decisions](ux-decisions.md)

--- a/docs/reading-mode.md
+++ b/docs/reading-mode.md
@@ -37,7 +37,7 @@ Reading mode embeds are **display only**. You cannot tap them to edit. Use Live 
 2. Obsidian renders markdown into HTML — image embed and Edit link appear together.
 3. Ink scans each paragraph (and similar blocks) for Ink embeds.
 4. Ink checks the Edit link to learn embed type, size, and framing.
-5. Ink loads the SVG file from your vault.
+5. Ink loads the SVG file from your vault via `vault.read` (same locked-preview path as Live Preview — see [Embed preview SVG loading](embed-preview-svg-loading.md)).
 6. Ink replaces the plain image block with its preview component.
 7. The preview inlines the SVG and applies theme colours (see [Ink colours and theming](ink-colours-and-theming.md)).
 
@@ -59,7 +59,7 @@ For implementation file paths and design alternatives, see [Reading mode embed r
 ## Technical gotchas
 
 1. **Two render paths** — CodeMirror widgets run in Live Preview only. Reading mode needs its own Ink step after Obsidian renders markdown.
-2. **Image tag vs inlined SVG** — A plain `<img>` tag cannot be recoloured by Ink’s theme CSS. Reading mode must swap to an inlined SVG preview.
+2. **Image tag vs inlined SVG** — A plain `<img>` tag cannot be recoloured by Ink’s theme CSS. Reading mode must swap to an inlined SVG preview. Do not load that preview through `getResourcePath` XHR or a writing `data:` URI — see [Embed preview SVG loading](embed-preview-svg-loading.md).
 3. **Edit link is required** — An image without the matching Edit link is treated as a normal attachment, not an Ink embed.
 4. **Timing** — Ink replaces embeds after the paragraph is complete. Partial renders during page build are skipped until the block is ready.
 5. **Same file, many notes** — Path resolution uses the note that contains the embed, not whichever file you have focused.
@@ -67,6 +67,7 @@ For implementation file paths and design alternatives, see [Reading mode embed r
 
 ## See also
 
+- [Embed preview SVG loading](embed-preview-svg-loading.md) — How locked previews read SVG without CORS / theming regressions
 - [Ink colours and theming](ink-colours-and-theming.md) — How stroke and line colours follow light/dark theme
 - [Reading mode embed rendering](reading-mode-embed-rendering.md) — Implementation detail and design choices
 - [Ink embeds: contexts and limitations](ink-embeds-contexts-and-limitations.md) — Where embeds work across Obsidian views

--- a/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.tsx
+++ b/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.tsx
@@ -119,14 +119,16 @@ export const DrawingEmbedPreview: React.FC<DrawingEmbedPreviewProps> = (props) =
             setFileSrc(null);
             return;
         }
-        const basePath = plugin.app.vault.getResourcePath(props.embeddedFile);
-        if (!basePath) {
+        void plugin.app.vault.read(props.embeddedFile).then((svgContent) => {
+            if (!svgContent) {
+                setFileSrc(null);
+                return;
+            }
+            const encoded = btoa(unescape(encodeURIComponent(svgContent)));
+            setFileSrc(`data:image/svg+xml;base64,${encoded}`);
+        }).catch(() => {
             setFileSrc(null);
-            return;
-        }
-        const mtime = props.embeddedFile.stat.mtime;
-        const separator = basePath.includes('?') ? '&' : '?';
-        setFileSrc(`${basePath}${separator}t=${mtime}`);
+        });
     }
 
 };

--- a/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.tsx
+++ b/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.tsx
@@ -119,13 +119,15 @@ export const DrawingEmbedPreview: React.FC<DrawingEmbedPreviewProps> = (props) =
             setFileSrc(null);
             return;
         }
+        // Prefer vault.read over getResourcePath: react-inlinesvg XHRs app:// URLs, which Electron 39+
+        // blocks as cross-origin from app://obsidian.md. Pass raw SVG markup so InlineSVG inlines
+        // into the DOM (theme CSS can restyle paths) without any network fetch.
         void plugin.app.vault.read(props.embeddedFile).then((svgContent) => {
             if (!svgContent) {
                 setFileSrc(null);
                 return;
             }
-            const encoded = btoa(unescape(encodeURIComponent(svgContent)));
-            setFileSrc(`data:image/svg+xml;base64,${encoded}`);
+            setFileSrc(svgContent);
         }).catch(() => {
             setFileSrc(null);
         });

--- a/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.tsx
+++ b/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.tsx
@@ -123,10 +123,12 @@ export const WritingEmbedPreview: React.FC<WritingEmbedPreviewProps> = (props) =
 
     function refreshSrc() {
         if (!props.writingFile) return;
+        // Prefer vault.read over getResourcePath: react-inlinesvg XHRs app:// URLs, which Electron 39+
+        // blocks as cross-origin from app://obsidian.md. Pass raw SVG markup (not a data URI) so we
+        // stay on the InlineSVG branch — data: would flip isImg and break dark-theme path CSS.
         void props.plugin.app.vault.read(props.writingFile).then((svgContent) => {
             if (!svgContent) return;
-            const encoded = btoa(unescape(encodeURIComponent(svgContent)));
-            setFileSrc(`data:image/svg+xml;base64,${encoded}`);
+            setFileSrc(svgContent);
         }).catch(() => {});
     }
 

--- a/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.tsx
+++ b/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.tsx
@@ -122,11 +122,12 @@ export const WritingEmbedPreview: React.FC<WritingEmbedPreviewProps> = (props) =
     }
 
     function refreshSrc() {
-        const basePath = props.plugin.app.vault.getResourcePath(props.writingFile);
-        if (!basePath) return;
-        const mtime = props.writingFile.stat.mtime;
-        const separator = basePath.includes('?') ? '&' : '?';
-        setFileSrc(`${basePath}${separator}t=${mtime}`);
+        if (!props.writingFile) return;
+        void props.plugin.app.vault.read(props.writingFile).then((svgContent) => {
+            if (!svgContent) return;
+            const encoded = btoa(unescape(encodeURIComponent(svgContent)));
+            setFileSrc(`data:image/svg+xml;base64,${encoded}`);
+        }).catch(() => {});
     }
 
 };


### PR DESCRIPTION
## Problem

On systems running Obsidian with a system-installed Electron 39+ (e.g. Arch/CachyOS-packaged Obsidian 2.1.2), the Ink plugin's preview/reading mode shows an empty placeholder instead of the handwriting/drawing, both in Live Preview and Reading View.

### Root Cause

The `DrawingEmbedPreview` and `WritingEmbedPreview` `refreshSrc()` functions use `app.vault.getResourcePath()` to obtain an `app://` URL, which `react-inlinesvg` then fetches via XHR. On Electron 39+, cross-origin `app://` requests are blocked by CORS policy:

```
Access to fetch at 'app://71f06d1f...' from origin 'app://obsidian.md' 
has been blocked by CORS policy: Cross origin requests are only supported 
for protocol schemes: chrome, chrome-extension, chrome-untrusted, data, http, https.
```

The page origin is `app://obsidian.md` while `getResourcePath()` returns a URL under `app://71f06d1f...` (a different origin), so the browser blocks the cross-origin XHR.

The **editor** mode works correctly because it uses `vault.read()` (Obsidian's internal file system API, not HTTP), which bypasses CORS entirely.

## Fix

Replace `app.vault.getResourcePath()` + XHR with `vault.read()` + base64 data URI in both preview components:

- `src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.tsx`
- `src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.tsx`

The `data:` scheme is explicitly allowed by the CORS policy, so `react-inlinesvg` can fetch the inline SVG without any cross-origin restrictions.

## Files changed

- `drawing-embed-preview.tsx`: `refreshSrc()` now reads SVG content via `vault.read()
  ` and encodes as base64 data URI
- `writing-embed-preview.tsx`: same fix

## Verification

- Tested on Obsidian 2.1.2 with system Electron 39 on Linux (Wayland)
- Confirmed via DevTools that `data:` URI fetches succeed where `app://` fails
- Both Live Preview and Reading View now render drawings/writings correctly
- Backward compatible: data URIs work identically regardless of Electron version

Fixes #194