### PR TITLE
Improve large Ink canvas performance

### DIFF
--- a/src/commands/prepare-ink-pdf-export.ts
+++ b/src/commands/prepare-ink-pdf-export.ts
@@ -1,0 +1,118 @@
+import { MarkdownView, Notice, TFile } from 'obsidian';
+import type InkPlugin from 'src/main';
+import {
+	allowNativeInkPdfPreviewsForNextExport,
+	getInkSourcePathFromEmbedPath,
+	writeInkPdfPreview,
+} from 'src/logic/utils/ink-pdf-export';
+
+const INK_IMAGE_MARKER_PATTERN = /!\[(InkWriting|InkDrawing)\]\(<([^>]+)>\)/g;
+
+export type PrepareInkPdfResult = {
+	prepared: number;
+	missing: number;
+};
+
+export async function prepareNoteInkForPdfExport(
+	plugin: InkPlugin,
+	note: TFile,
+): Promise<PrepareInkPdfResult> {
+	const markdown = await plugin.app.vault.read(note);
+	const sourcePaths = new Set<string>();
+
+	for (const match of markdown.matchAll(INK_IMAGE_MARKER_PATTERN)) {
+		sourcePaths.add(getInkSourcePathFromEmbedPath(match[2]));
+	}
+
+	let prepared = 0;
+	let missing = 0;
+	const previewBySourcePath = new Map<string, string>();
+
+	for (const sourcePath of sourcePaths) {
+		const sourceFile = plugin.app.metadataCache.getFirstLinkpathDest(sourcePath, note.path);
+		if (!(sourceFile instanceof TFile) || sourceFile.extension.toLowerCase() !== 'svg') {
+			missing += 1;
+			continue;
+		}
+
+		const previewPath = await writeInkPdfPreview(plugin, sourceFile);
+		previewBySourcePath.set(sourcePath, previewPath);
+		prepared += 1;
+	}
+
+	const updatedMarkdown = markdown.replace(
+		INK_IMAGE_MARKER_PATTERN,
+		(fullMarker, altText: string, markerPath: string) => {
+			const sourcePath = getInkSourcePathFromEmbedPath(markerPath);
+			const previewPath = previewBySourcePath.get(sourcePath);
+			if (!previewPath) return fullMarker;
+			return `![${altText}](<${previewPath}>)`;
+		},
+	);
+
+	if (updatedMarkdown !== markdown) {
+		await plugin.app.vault.modify(note, updatedMarkdown);
+	}
+
+	return { prepared, missing };
+}
+
+export function registerPrepareInkPdfExportCommand(plugin: InkPlugin): void {
+	plugin.addCommand({
+		id: 'prepare-current-note-ink-for-pdf-export',
+		name: 'Prepare current note handwriting for PDF export',
+		checkCallback: (checking) => {
+			const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+			if (!view?.file) return false;
+			if (checking) return true;
+
+			void (async () => {
+				new Notice('Preparing Ink handwriting for PDF export…');
+				try {
+					const result = await prepareNoteInkForPdfExport(plugin, view.file as TFile);
+					const missingSuffix = result.missing > 0
+						? ` (${result.missing} missing attachment${result.missing === 1 ? '' : 's'} skipped)`
+						: '';
+					new Notice(`Ink PDF previews ready: ${result.prepared}${missingSuffix}`);
+				} catch (error) {
+					console.error('Unable to prepare Ink handwriting for PDF export', error);
+					new Notice('Could not prepare Ink handwriting for PDF export. See console for details.');
+				}
+			})();
+			return true;
+		},
+	});
+
+	plugin.addCommand({
+		id: 'export-current-note-to-pdf-with-ink',
+		name: 'Export current note to PDF with Ink',
+		checkCallback: (checking) => {
+			const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+			if (!view?.file) return false;
+			if (checking) return true;
+
+			void (async () => {
+				new Notice('Preparing Ink handwriting for PDF export…');
+				try {
+					const result = await prepareNoteInkForPdfExport(plugin, view.file as TFile);
+					allowNativeInkPdfPreviewsForNextExport();
+					const appWithCommands = plugin.app as typeof plugin.app & {
+						commands?: { executeCommandById: (id: string) => boolean };
+					};
+					const opened = appWithCommands.commands?.executeCommandById('workspace:export-pdf') ?? false;
+					if (!opened) {
+						new Notice('Ink previews are ready. Run Obsidian’s “Export to PDF” command now.');
+						return;
+					}
+					if (result.missing > 0) {
+						new Notice(`${result.missing} missing Ink attachment${result.missing === 1 ? '' : 's'} skipped.`);
+					}
+				} catch (error) {
+					console.error('Unable to export PDF with Ink handwriting', error);
+					new Notice('Could not prepare Ink handwriting for PDF export. See console for details.');
+				}
+			})();
+			return true;
+		},
+	});
+}

--- a/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.scss
+++ b/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.scss
@@ -1,5 +1,3 @@
-@use '../../../shared/ink-svg-preview-theme';
-
 /////////
 /////////
 

--- a/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
+++ b/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
@@ -1,13 +1,13 @@
 import './drawing-editor.scss';
 import * as React from 'react';
 import { useRef } from 'react';
-import { TFile } from 'obsidian';
+import { Platform, TFile } from 'obsidian';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
 import { InkFileData } from 'src/components/formats/current/types/file-data';
 import { buildInkCanvasDrawingFileData } from 'src/components/formats/current/utils/build-file-data';
 import { isInkCanvasFile } from 'src/components/formats/current/utils/ink-file-storage-engine';
-import { DRAW_SHORT_DELAY_MS, DRAW_LONG_DELAY_MS } from 'src/constants';
+import { DRAW_LONG_DELAY_MS, DRAW_SHORT_DELAY_MS } from 'src/constants';
 import { PrimaryMenuBar } from 'src/components/jsx-components/primary-menu-bar/primary-menu-bar';
 import { InkCanvasDrawingMenu } from 'src/components/jsx-components/drawing-menu/ink-canvas-drawing-menu';
 import ExtendedDrawingMenu from 'src/components/jsx-components/extended-drawing-menu/extended-drawing-menu';
@@ -32,6 +32,7 @@ import {
 } from 'src/logic/undo-redo/embedded-unified-undo';
 import { InkSvgCanvas } from 'src/ink-canvas/ink-svg-canvas';
 import { renderStrokesToSvg } from 'src/ink-canvas/svg-export';
+import { resolveInkAutosaveDelayMs } from 'src/ink-canvas/autosave-delay';
 import { migrateFromTldraw } from 'src/ink-canvas/migrate-from-tldraw';
 import { useDominantHand } from 'src/stores/dominant-hand-store';
 import { Notice } from 'obsidian';
@@ -102,7 +103,8 @@ export function DrawingEditor(props: DrawingEditorProps) {
 	const [isFingerDrawingActive, setIsFingerDrawingActive] = React.useState(false);
 	const [initialSnapshot, setInitialSnapshot] = React.useState<InkCanvasSnapshot>();
 	const shortDelayTimerRef = useRef<number>();
-	const longDelayTimerRef = useRef<number>();
+	const canvasInteractionActiveRef = useRef(false);
+	const hasUnsavedChangesRef = useRef(false);
 	const editorRef = useRef<InkCanvasEditor>();
 	const editorWrapperRefEl = useRef<HTMLDivElement>(null);
 	const websocketConnectedRef = useRef(false);
@@ -351,7 +353,17 @@ export function DrawingEditor(props: DrawingEditorProps) {
 	}
 
 	function handleStoreChange() {
+		hasUnsavedChangesRef.current = true;
 		queueSaves();
+	}
+
+	function handleCanvasInteractionChange(active: boolean) {
+		canvasInteractionActiveRef.current = active;
+		if (active) {
+			resetTimers();
+			return;
+		}
+		if (hasUnsavedChangesRef.current) queueSaves();
 	}
 
 	function handleEmbedUndoStackPush() {
@@ -366,15 +378,18 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 	function queueSaves() {
 		resetTimers();
+		if (canvasInteractionActiveRef.current) return;
+		const delayMs = resolveInkAutosaveDelayMs(Platform, DRAW_SHORT_DELAY_MS, DRAW_LONG_DELAY_MS);
 		shortDelayTimerRef.current = window.setTimeout(() => {
 			void incrementalSave();
-		}, DRAW_SHORT_DELAY_MS);
-		longDelayTimerRef.current = window.setTimeout(() => {
-			void completeSave();
-		}, DRAW_LONG_DELAY_MS);
+		}, delayMs);
 	}
 
 	async function incrementalSave() {
+		if (canvasInteractionActiveRef.current) {
+			queueSaves();
+			return;
+		}
 		const editor = editorRef.current;
 		if (!editor) return;
 		verbose('incrementalSave (ink-canvas)');
@@ -382,6 +397,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 		const snapshot = editor.getSnapshot();
 		const svgString = renderStrokesToSvg(snapshot.strokes, snapshot);
+		hasUnsavedChangesRef.current = false;
 		const fileData = buildInkCanvasDrawingFileData({
 			inkCanvasSnapshot: snapshot,
 			svgString,
@@ -397,6 +413,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 		const snapshot = editor.getSnapshot();
 		const svgString = renderStrokesToSvg(snapshot.strokes, snapshot);
+		hasUnsavedChangesRef.current = false;
 		const fileData = buildInkCanvasDrawingFileData({
 			inkCanvasSnapshot: snapshot,
 			svgString,
@@ -406,7 +423,6 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 	function resetTimers() {
 		window.clearTimeout(shortDelayTimerRef.current);
-		window.clearTimeout(longDelayTimerRef.current);
 	}
 
 
@@ -754,6 +770,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 				initialSnapshot={initialSnapshot}
 				onEditorReady={handleEditorReady}
 				onChange={handleStoreChange}
+				onInteractionChange={handleCanvasInteractionChange}
 				onEmbedUndoStackPush={handleEmbedUndoStackPush}
 				onCameraChange={(camera, containerRect, meta) => {
 					if (meta.source === 'user') hasUserMovedCameraRef.current = true;

--- a/src/components/formats/current/drawing/drawing-embed-extension/drawing-embed-extension.tsx
+++ b/src/components/formats/current/drawing/drawing-embed-extension/drawing-embed-extension.tsx
@@ -29,6 +29,10 @@ import { preventWidgetRootStealingFocus } from '../../utils/preventWidgetRootSte
 import { preventCodeMirrorHandlingWidgetsEvents } from '../../utils/createWidgetRootDomEventHandlers';
 import { parseSettingsFromUrl } from '../../utils/parse-settings-from-url';
 import { buildFileStr } from '../../utils/buildFileStr';
+import {
+	getInkSourcePathFromEmbedPath,
+	scheduleInkPdfPreviewRefresh,
+} from 'src/logic/utils/ink-pdf-export';
 import { buildDrawingEmbedLine, buildWritingEmbedLine } from '../../utils/build-embeds';
 import { buildDrawingEmbedSettingsFromFile } from 'src/logic/utils/build-drawing-embed-settings-from-file';
 import { duplicateDrawingFile } from '../../utils/duplicate-files';
@@ -191,6 +195,7 @@ export class DrawingEmbedWidget extends WidgetType {
 		const plugin = getGlobals().plugin;
 		const inkFileContents = buildFileStr(inkFileData);
 		await plugin.app.vault.modify(this.embeddedFile, inkFileContents);
+		scheduleInkPdfPreviewRefresh(plugin, this.embeddedFile, inkFileData.svgString);
 	}
 
 	setEmbedProps = async (view: EditorView, width: number, aspectRatio: number) => {
@@ -843,6 +848,7 @@ function detectMarkdownEmbedLink(mdFile: TFile, previewLinkStartNode: SyntaxNode
     
     // It's definitely a markdown embed, let's now focus on the urlText to check it's an Ink embed.
     const previewPartialFilepath = transaction.state.doc.sliceString(previewFilepathNode.from+1, previewFilepathNode.to-1); // +&- to remove <> brackets
+	const inkSourceFilepath = getInkSourcePathFromEmbedPath(previewPartialFilepath);
     const urlAndSettings = transaction.state.doc.sliceString(settingsUrlPathNode.from, settingsUrlPathNode.to);
     // Require query param to include type=InkDrawing (host agnostic)
     if (!urlAndSettings.includes('type=inkDrawing')) {
@@ -867,7 +873,7 @@ function detectMarkdownEmbedLink(mdFile: TFile, previewLinkStartNode: SyntaxNode
     //     embedSettings.transcription = transaction.state.doc.sliceString(altTextNode.from, altTextNode.to);
     // }
 
-    const embeddedFile = plugin.app.metadataCache.getFirstLinkpathDest(normalizePath(previewPartialFilepath), mdFile.path)
+    const embeddedFile = plugin.app.metadataCache.getFirstLinkpathDest(normalizePath(inkSourceFilepath), mdFile.path)
 
     return {
         embedLinkInfo: {
@@ -875,7 +881,7 @@ function detectMarkdownEmbedLink(mdFile: TFile, previewLinkStartNode: SyntaxNode
             endPosition: endOfReplacement,
             embeddedFile: embeddedFile,
             embedSettings: embedSettings,
-            partialEmbedFilepath: previewPartialFilepath,
+            partialEmbedFilepath: inkSourceFilepath,
             isPendingPaste: isPendingPaste,
         },
     }

--- a/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.scss
+++ b/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.scss
@@ -1,5 +1,3 @@
-@use '../../../../shared/ink-svg-preview-theme';
-
 .ddc_ink_drawing-embed-preview {
     pointer-events: none;
 

--- a/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.tsx
+++ b/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.tsx
@@ -93,7 +93,7 @@ export const DrawingEmbedPreview: React.FC<DrawingEmbedPreviewProps> = (props) =
                         cursor: 'pointer'
                     }}
                     pointerEvents = "visible"
-                    cacheRequests = {false}
+                    cacheRequests = {true}
                     key = {fileSrc}
                     onLoad = {onLoad}
                     viewBox = {props.embedSettings?.viewBox

--- a/src/components/formats/current/drawing/drawing-embed/drawing-embed.scss
+++ b/src/components/formats/current/drawing/drawing-embed/drawing-embed.scss
@@ -1,4 +1,3 @@
-@use '../../../../shared/ink-svg-preview-theme';
 @use '../../../../../styles/ink-boox-eink-chrome';
 
 // Boox: disable transition on the editor canvas only (stroke latency).

--- a/src/components/formats/current/drawing/drawing-view/drawing-view.tsx
+++ b/src/components/formats/current/drawing/drawing-view/drawing-view.tsx
@@ -7,6 +7,7 @@ import {
 	Provider as JotaiProvider
 } from "jotai";
 import { buildFileStr } from "../../utils/buildFileStr";
+import { scheduleInkPdfPreviewRefresh } from 'src/logic/utils/ink-pdf-export';
 import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
 import { ensureThemedNativeInkSvgView } from "src/logic/utils/addEditButtonToSvgView";
 import { openInkFileInView, restoreSidebarsAfterInkView } from "src/logic/utils/open-file";
@@ -184,6 +185,7 @@ export class DrawingView extends TextFileView {
 
     saveFile = (inkFileData: InkFileData) => {
         this.inkFileData = inkFileData;
+		if (this.file) scheduleInkPdfPreviewRefresh(this.plugin, this.file, inkFileData.svgString);
         void this.save(false);   // Obsidian will call getViewData during this method
     }
     

--- a/src/components/formats/current/reading-mode/ink-reading-embed-host.tsx
+++ b/src/components/formats/current/reading-mode/ink-reading-embed-host.tsx
@@ -30,7 +30,6 @@ export type InkReadingEmbedHostParams = {
 export class InkReadingEmbedHost extends MarkdownRenderChild {
 	private reactRoot: Root | null = null;
 	private resizeObserver: ResizeObserver | null = null;
-	private pageResizeObserver: ResizeObserver | null = null;
 	private resizeContainerEl: HTMLElement | null = null;
 	private writingFileModifyRef: ReturnType<InkPlugin['app']['vault']['on']> | null = null;
 
@@ -40,10 +39,6 @@ export class InkReadingEmbedHost extends MarkdownRenderChild {
 	) {
 		super(containerEl);
 	}
-
-	private handleWindowResize = () => {
-		this.applyDimensions();
-	};
 
 	onload(): void {
 		this.containerEl.removeAttribute(INK_READING_MOUNTING_ATTR);
@@ -63,14 +58,11 @@ export class InkReadingEmbedHost extends MarkdownRenderChild {
 				onMount={(_embedEl, resizeContainerEl) => {
 					this.resizeContainerEl = resizeContainerEl;
 					this.attachResizeObserver(resizeContainerEl);
-					this.attachPageResizeObserver(resizeContainerEl);
 					this.applyDimensions();
 					void this.syncWritingAspectRatioFromFile();
 				}}
 			/>,
 		);
-
-		window.addEventListener('resize', this.handleWindowResize);
 
 		if (this.params.embedKind === 'writing' && this.params.embeddedFile) {
 			const writingFilePath = this.params.embeddedFile.path;
@@ -83,13 +75,10 @@ export class InkReadingEmbedHost extends MarkdownRenderChild {
 	}
 
 	onunload(): void {
-		window.removeEventListener('resize', this.handleWindowResize);
 		if (this.writingFileModifyRef) {
 			this.params.plugin.app.vault.offref(this.writingFileModifyRef);
 			this.writingFileModifyRef = null;
 		}
-		this.pageResizeObserver?.disconnect();
-		this.pageResizeObserver = null;
 		this.resizeContainerEl = null;
 		this.containerEl.removeAttribute(INK_READING_ACTIVE_ATTR);
 		this.containerEl.removeAttribute(INK_READING_MOUNTING_ATTR);
@@ -135,20 +124,12 @@ export class InkReadingEmbedHost extends MarkdownRenderChild {
 			this.applyDimensions();
 		});
 		this.resizeObserver.observe(resizeContainerEl);
-	}
-
-	private attachPageResizeObserver(resizeContainerEl: HTMLElement | null) {
-		if (!resizeContainerEl) return;
 
 		const pageEl = resizeContainerEl.closest('.markdown-preview-view')
 			?? resizeContainerEl.closest('.markdown-reading-view');
-		if (!(pageEl instanceof HTMLElement)) return;
-
-		this.pageResizeObserver?.disconnect();
-		this.pageResizeObserver = new ResizeObserver(() => {
-			this.applyDimensions();
-		});
-		this.pageResizeObserver.observe(pageEl);
+		if (pageEl instanceof HTMLElement && pageEl !== resizeContainerEl) {
+			this.resizeObserver.observe(pageEl);
+		}
 	}
 }
 

--- a/src/components/formats/current/reading-mode/register-reading-mode-ink-embeds.ts
+++ b/src/components/formats/current/reading-mode/register-reading-mode-ink-embeds.ts
@@ -24,6 +24,7 @@ const INK_READING_EMBED_KIND_DATA = 'inkEmbedKind';
 const INK_READING_FILE_PATH_DATA = 'inkFilePath';
 const INK_READING_EMBED_SETTINGS_DATA = 'inkEmbedSettings';
 const INK_READING_SOURCE_PATH_DATA = 'inkSourcePath';
+const INK_READING_HOST_SELECTOR = `.ddc_ink_reading-embed-host[${INK_READING_PROCESSED_ATTR}]`;
 
 export function registerReadingModeInkEmbeds(plugin: InkPlugin) {
 	// Run late so block containers include the full embed marker + Edit link row.
@@ -45,8 +46,12 @@ export function registerReadingModeInkEmbeds(plugin: InkPlugin) {
 	// Obsidian may reuse cached reading-view DOM when toggling LP ↔ RM. MarkdownRenderChild
 	// onunload clears React content but leaves host shells — remount when preview is shown again.
 	// When returning to Live Preview, rebuild CM embed widgets (they only refresh on down-scroll otherwise).
+	let refreshScheduled = false;
 	const scheduleReadingModeOrLivePreviewEmbedRefresh = () => {
+		if (refreshScheduled) return;
+		refreshScheduled = true;
 		queueMicrotask(() => {
+			refreshScheduled = false;
 			const markdownView = plugin.app.workspace.getActiveViewOfType(MarkdownView);
 			if (!markdownView) return;
 
@@ -72,6 +77,9 @@ function processReadingModeInkEmbedsInRoot(
 		rootEl,
 		context.sourcePath,
 	);
+	const containsMountedHost = rootEl.matches(INK_READING_HOST_SELECTOR)
+		|| rootEl.querySelector(INK_READING_HOST_SELECTOR) !== null;
+	if (candidates.length === 0 && !containsMountedHost) return;
 
 	// Replace last-to-first so earlier DOM ranges stay valid while iterating.
 	const sortedCandidates = [...candidates].sort((a, b) => {
@@ -106,7 +114,8 @@ function processReadingModeInkEmbedsInRoot(
 	// (active but no .ddc_ink_embed yet), re-mounts via plugin.addChild, and never unloads,
 	// leaving Obsidian's export progress bar stuck.
 	// Popout-safe: schedule on the window that owns this preview root.
-	window.requestAnimationFrame(() => {
+	const rootWindow = rootEl.ownerDocument.defaultView ?? window;
+	rootWindow.requestAnimationFrame(() => {
 		if (!isFullPageRoot) {
 			remountStaleReadingEmbedHostsInRoot(plugin, rootEl, context.sourcePath);
 		}
@@ -136,9 +145,7 @@ function remountStaleReadingEmbedHostsInRoot(
 	rootEl: HTMLElement,
 	sourcePath: string,
 ) {
-	const staleHostEls = [...rootEl.querySelectorAll<HTMLElement>(
-		`.ddc_ink_reading-embed-host[${INK_READING_PROCESSED_ATTR}]`,
-	)].filter((hostEl) => {
+	const staleHostEls = [...rootEl.querySelectorAll<HTMLElement>(INK_READING_HOST_SELECTOR)].filter((hostEl) => {
 		if (hostEl.hasAttribute(INK_READING_MOUNTING_ATTR)) return false;
 		if (!hostEl.hasAttribute(INK_READING_ACTIVE_ATTR)) return true;
 		return !hostEl.querySelector('.ddc_ink_embed');

--- a/src/components/formats/current/reading-mode/register-reading-mode-ink-embeds.ts
+++ b/src/components/formats/current/reading-mode/register-reading-mode-ink-embeds.ts
@@ -11,6 +11,7 @@ import { InkEmbedKind } from 'src/logic/utils/embed';
 import { EmbedSettings } from 'src/types/embed-settings';
 import { InkReadingEmbedHost, refreshReadingModeEmbedDimensionsInRoot } from './ink-reading-embed-host';
 import { refreshLivePreviewEmbedsWhenReady } from '../ink-embeds-extension/ink-embed-refresh';
+import { shouldUseNativeInkPdfPreviews } from 'src/logic/utils/ink-pdf-export';
 import '../drawing/drawing-embed/drawing-embed.scss';
 import '../drawing/drawing-embed-preview/drawing-embed-preview.scss';
 import '../writing/writing-embed/writing-embed.scss';
@@ -31,6 +32,10 @@ export function registerReadingModeInkEmbeds(plugin: InkPlugin) {
 	// Reading mode passes section elements (p, .el-p, …); PDF export passes the entire
 	// .markdown-preview-view — both roots must be accepted or export shows the full SVG.
 	plugin.registerMarkdownPostProcessor((element, context) => {
+		// The PDF-safe command deliberately leaves PNG companion markers native.
+		// Obsidian's exporter includes PNGs but drops the themed inline SVG host.
+		if (shouldUseNativeInkPdfPreviews()) return;
+
 		const matchesScanRoot = element.matches(READING_MODE_EMBED_SCAN_ROOT_SELECTOR);
 		const isFullPagePreviewRoot = element.matches(FULL_PAGE_PREVIEW_ROOT_SELECTOR);
 		if (!matchesScanRoot && !isFullPagePreviewRoot) return;

--- a/src/components/formats/current/utils/buildFileStr.ts
+++ b/src/components/formats/current/utils/buildFileStr.ts
@@ -33,14 +33,12 @@ function buildInkCanvasFileStr(pageData: InkFileData): string {
         '</metadata>',
     ].join('\n');
 
-    const metadataPattern = /<metadata\b[^>]*>[\s\S]*?<\/metadata>/i;
-    if (metadataPattern.test(fileStr)) {
-        return fileStr.replace(metadataPattern, metadata);
-    }
+    const metadataPattern = /<metadata\b[^>]*>[\s\S]*?<\/metadata>/gi;
+    const fileWithoutMetadata = fileStr.replace(metadataPattern, '');
 
     const svgOpenPattern = /<svg\b[^>]*>/i;
-    if (svgOpenPattern.test(fileStr)) {
-        return fileStr.replace(svgOpenPattern, (svgOpen) => `${svgOpen}\n${metadata}`);
+    if (svgOpenPattern.test(fileWithoutMetadata)) {
+        return fileWithoutMetadata.replace(svgOpenPattern, (svgOpen) => `${svgOpen}\n${metadata}`);
     }
 
     return `<svg xmlns="http://www.w3.org/2000/svg">\n${metadata}\n</svg>`;

--- a/src/components/formats/current/utils/buildFileStr.ts
+++ b/src/components/formats/current/utils/buildFileStr.ts
@@ -20,42 +20,43 @@ export const buildFileStr = (pageData: InkFileData): string => {
 //////////////////////////
 
 function buildInkCanvasFileStr(pageData: InkFileData): string {
-    // For ink-canvas files, the svgString already contains the full SVG with
-    // <ink-canvas> metadata (produced by svg-export.ts). We just need to ensure
-    // the <ink> meta element is present with plugin-version and file-type.
-    let fileStr = pageData.svgString || '<svg></svg>';
+    // The ink-canvas renderer already gives us a complete SVG. Re-parsing and
+    // pretty-printing that multi-megabyte document on every autosave blocks the
+    // input thread in direct proportion to the number of strokes. Replace just
+    // the small metadata block and keep the rendered path markup untouched.
+    const fileStr = pageData.svgString || '<svg></svg>';
+    const snapshotJson = escapeXmlText(JSON.stringify(pageData.inkCanvas));
+    const metadata = [
+        '<metadata>',
+        `<ink plugin-version="${escapeXmlAttribute(String(pageData.meta.pluginVersion))}" file-type="${escapeXmlAttribute(pageData.meta.fileType)}"/>`,
+        `<ink-canvas version="${escapeXmlAttribute(INK_CANVAS_FORMAT_VERSION)}">${snapshotJson}</ink-canvas>`,
+        '</metadata>',
+    ].join('\n');
 
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(fileStr, 'image/svg+xml');
-    const svgElement = doc.documentElement;
-
-    // Remove existing metadata to rebuild cleanly
-    const existingMetadata = svgElement.getElementsByTagName('metadata');
-    while (existingMetadata.length > 0) {
-        existingMetadata[0].parentNode?.removeChild(existingMetadata[0]);
+    const metadataPattern = /<metadata\b[^>]*>[\s\S]*?<\/metadata>/i;
+    if (metadataPattern.test(fileStr)) {
+        return fileStr.replace(metadataPattern, metadata);
     }
 
-    const metadataElement = doc.createElement('metadata');
+    const svgOpenPattern = /<svg\b[^>]*>/i;
+    if (svgOpenPattern.test(fileStr)) {
+        return fileStr.replace(svgOpenPattern, (svgOpen) => `${svgOpen}\n${metadata}`);
+    }
 
-    // <ink> meta
-    const inkMetaElement = doc.createElement('ink');
-    inkMetaElement.setAttribute('plugin-version', String(pageData.meta.pluginVersion));
-    inkMetaElement.setAttribute('file-type', pageData.meta.fileType);
-    metadataElement.appendChild(inkMetaElement);
+    return `<svg xmlns="http://www.w3.org/2000/svg">\n${metadata}\n</svg>`;
+}
 
-    // <ink-canvas version="0.5.0"> JSON </ink-canvas>
-    const inkCanvasElement = doc.createElement('ink-canvas');
-    inkCanvasElement.setAttribute('version', INK_CANVAS_FORMAT_VERSION);
-    inkCanvasElement.textContent = JSON.stringify(pageData.inkCanvas, null, 2);
-    metadataElement.appendChild(inkCanvasElement);
+function escapeXmlText(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
 
-    svgElement.appendChild(metadataElement);
-
-    const serializedSvg = new XMLSerializer().serializeToString(svgElement);
-    return format(serializedSvg, {
-        indentation: '\t',
-        lineSeparator: '\n'
-    });
+function escapeXmlAttribute(value: string): string {
+    return escapeXmlText(value)
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
 }
 
 

--- a/src/components/formats/current/writing/writing-editor/writing-editor.tsx
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.tsx
@@ -1,7 +1,7 @@
 import './writing-editor.scss';
 import * as React from 'react';
 import { useRef } from 'react';
-import { TFile } from 'obsidian';
+import { Platform, TFile } from 'obsidian';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
 import InkPlugin from 'src/main';
@@ -39,6 +39,7 @@ import {
 } from 'src/logic/undo-redo/embedded-unified-undo';
 import { InkSvgCanvas } from 'src/ink-canvas/ink-svg-canvas';
 import { renderWritingStrokesToSvg } from 'src/ink-canvas/svg-export';
+import { resolveInkAutosaveDelayMs } from 'src/ink-canvas/autosave-delay';
 import { computeApproxContentMaxY } from 'src/ink-canvas/stroke-viewport-culling';
 import { migrateWritingFromTldraw } from 'src/ink-canvas/migrate-from-tldraw';
 import type { PageBounds } from './page-bounds';
@@ -107,7 +108,9 @@ export function WritingEditor(props: WritingEditorProps) {
 	const [booxConnected, setBooxConnected] = React.useState(false);
 	const resizePostProcessTimeoutRef = useRef<number>();
 	const shortDelayTimerRef = useRef<number>();
-	const longDelayTimerRef = useRef<number>();
+	const canvasInteractionActiveRef = useRef(false);
+	const hasUnsavedChangesRef = useRef(false);
+	const latestInvitingHeightRef = useRef(0);
 	const editorRef = useRef<InkCanvasEditor>();
 	const editorWrapperRefEl = useRef<HTMLDivElement>(null);
 	const websocketConnectedRef = useRef(false);
@@ -459,10 +462,20 @@ export function WritingEditor(props: WritingEditorProps) {
 	}
 
 	function handleStoreChange() {
+		hasUnsavedChangesRef.current = true;
 		queueSaves();
 		if (props.embedded) {
 			debouncedEmbedResizePostProcess();
 		}
+	}
+
+	function handleCanvasInteractionChange(active: boolean) {
+		canvasInteractionActiveRef.current = active;
+		if (active) {
+			resetTimers();
+			return;
+		}
+		if (hasUnsavedChangesRef.current) queueSaves();
 	}
 
 	function handleEmbedUndoStackPush() {
@@ -485,7 +498,7 @@ export function WritingEditor(props: WritingEditorProps) {
 			const editor = editorRef.current;
 			if (!editor || !props.embedded) return;
 			if (websocketConnectedRef.current && getBooxConnectionEnabled()) return;
-			const invitingHeight = getInvitingHeightFromEditor(editor);
+			const invitingHeight = latestInvitingHeightRef.current || getInvitingHeightFromEditor(editor);
 			if (!shouldResizeForNewHeight(
 				invitingHeight,
 				curHeightRef.current,
@@ -499,6 +512,7 @@ export function WritingEditor(props: WritingEditorProps) {
 	}
 
 	function handlePageHeightChange(candidateHeightPx: number) {
+		latestInvitingHeightRef.current = candidateHeightPx;
 		applyPageHeightChange(candidateHeightPx, false);
 	}
 
@@ -508,7 +522,10 @@ export function WritingEditor(props: WritingEditorProps) {
 
 		const lineHeight = writingLineHeightRef.current;
 		const bufferLines = props.plugin.settings.writingBufferLines;
-		const invitingFromContent = getInvitingHeightFromEditor(editor);
+		const invitingFromContent = candidateHeightPx > 0
+			? candidateHeightPx
+			: getInvitingHeightFromEditor(editor);
+		latestInvitingHeightRef.current = invitingFromContent;
 
 		if (props.embedded) {
 			const skipAutoResize = !forceNextPageHeightChangeRef.current
@@ -587,20 +604,24 @@ export function WritingEditor(props: WritingEditorProps) {
 
 	function queueSaves() {
 		resetTimers();
+		if (canvasInteractionActiveRef.current) return;
+		const delayMs = resolveInkAutosaveDelayMs(Platform, WRITE_SHORT_DELAY_MS, WRITE_LONG_DELAY_MS);
 		shortDelayTimerRef.current = window.setTimeout(() => {
 			void incrementalSave();
-		}, WRITE_SHORT_DELAY_MS);
-		longDelayTimerRef.current = window.setTimeout(() => {
-			void completeSave();
-		}, WRITE_LONG_DELAY_MS);
+		}, delayMs);
 	}
 
 	async function incrementalSave() {
+		if (canvasInteractionActiveRef.current) {
+			queueSaves();
+			return;
+		}
 		const editor = editorRef.current;
 		if (!editor) return;
 		verbose('incrementalSave (ink-canvas writing)');
 		const snapshot = editor.getSnapshot();
 		const svgString = renderWritingStrokesToSvg(snapshot.strokes, snapshot, WRITING_PAGE_WIDTH);
+		hasUnsavedChangesRef.current = false;
 		props.save(buildInkCanvasWritingFileData({ inkCanvasSnapshot: snapshot, svgString }));
 	}
 
@@ -610,13 +631,13 @@ export function WritingEditor(props: WritingEditorProps) {
 		verbose('completeSave (ink-canvas writing)');
 		const snapshot = editor.getSnapshot();
 		const svgString = renderWritingStrokesToSvg(snapshot.strokes, snapshot, WRITING_PAGE_WIDTH);
+		hasUnsavedChangesRef.current = false;
 		props.save(buildInkCanvasWritingFileData({ inkCanvasSnapshot: snapshot, svgString }));
 	}
 
 	function resetTimers() {
 		cancelDelayedBooxResizePostProcess();
 		window.clearTimeout(shortDelayTimerRef.current);
-		window.clearTimeout(longDelayTimerRef.current);
 	}
 
 	async function fetchFileData() {
@@ -929,6 +950,7 @@ export function WritingEditor(props: WritingEditorProps) {
 			writingBufferLines={props.plugin.settings.writingBufferLines}
 			onEditorReady={handleEditorReady}
 			onChange={handleStoreChange}
+			onInteractionChange={handleCanvasInteractionChange}
 			onEmbedUndoStackPush={handleEmbedUndoStackPush}
 			onPageHeightChange={handlePageHeightChange}
 			isEmbedded={props.embedded}

--- a/src/components/formats/current/writing/writing-embed-extension/writing-embed-extension.tsx
+++ b/src/components/formats/current/writing/writing-embed-extension/writing-embed-extension.tsx
@@ -30,6 +30,10 @@ import {
 	patchWritingEmbedAspectRatioInEmbedSnippet,
 	readWritingFileAspectRatio,
 } from 'src/logic/utils/writing-embed-aspect-ratio';
+import {
+	getInkSourcePathFromEmbedPath,
+	scheduleInkPdfPreviewRefresh,
+} from 'src/logic/utils/ink-pdf-export';
 
 
 // Parity with drawing v2, but simplified (no width/aspect updates for writing embeds)
@@ -189,6 +193,7 @@ export class WritingEmbedWidget extends WidgetType {
         const plugin = getGlobals().plugin;
         const pageDataStr = buildFileStr(pageData);
         await plugin.app.vault.modify(this.embeddedFile, pageDataStr);
+		scheduleInkPdfPreviewRefresh(plugin, this.embeddedFile, pageData.svgString);
     };
 
     private onRequestMeasure(view: EditorView) {
@@ -667,13 +672,14 @@ function detectMarkdownEmbedLinkWriting(
     }
 
     const previewPartialFilepath = transaction.state.doc.sliceString(previewFilepathNode.from + 1, previewFilepathNode.to - 1);
+	const inkSourceFilepath = getInkSourcePathFromEmbedPath(previewPartialFilepath);
     const startOfReplacement = previewLinkStartNode.from;
     const endOfReplacement = settingsUrlEndNode.to;
 
     // Parse settings from URL parameters
     const { embedSettings, isPendingPaste } = parseSettingsFromUrl(urlAndSettings);
 
-    const embeddedFile = plugin.app.metadataCache.getFirstLinkpathDest(normalizePath(previewPartialFilepath), mdFile.path);
+    const embeddedFile = plugin.app.metadataCache.getFirstLinkpathDest(normalizePath(inkSourceFilepath), mdFile.path);
 
     return {
         embedLinkInfo: {
@@ -681,7 +687,7 @@ function detectMarkdownEmbedLinkWriting(
             endPosition: endOfReplacement,
             embeddedFile: embeddedFile,
             embedSettings: embedSettings,
-            partialEmbedFilepath: previewPartialFilepath,
+            partialEmbedFilepath: inkSourceFilepath,
             isPendingPaste: isPendingPaste,
         },
     };

--- a/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.scss
+++ b/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.scss
@@ -1,5 +1,3 @@
-@use '../../../../shared/ink-svg-preview-theme';
-
 .ddc_ink_writing-embed-preview {
     pointer-events: none;
 

--- a/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.tsx
+++ b/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.tsx
@@ -97,7 +97,7 @@ export const WritingEmbedPreview: React.FC<WritingEmbedPreviewProps> = (props) =
             {!isImg && (<>
                 <SVG
                     src={fileSrc}
-                    cacheRequests={false}
+                    cacheRequests={true}
                     key={fileSrc}
                     style={{
                         width: '100%',
@@ -118,8 +118,7 @@ export const WritingEmbedPreview: React.FC<WritingEmbedPreviewProps> = (props) =
     ///////////////////
 
     function onLoad() {
-        // Slight delay on transition because otherwise a flicker is sometimes seen
-        window.setTimeout(() => {}, 100);
+        // Kept as a callback for parity with drawing previews.
     }
 
     function refreshSrc() {

--- a/src/components/formats/current/writing/writing-view/writing-view.tsx
+++ b/src/components/formats/current/writing/writing-view/writing-view.tsx
@@ -7,6 +7,7 @@ import { InkFileData } from "src/components/formats/current/types/file-data";
 import { WritingEditor } from "../writing-editor/writing-editor";
 import { type MenuOption } from "src/components/jsx-components/overflow-menu/overflow-menu";
 import { buildFileStr } from "../../utils/buildFileStr";
+import { scheduleInkPdfPreviewRefresh } from 'src/logic/utils/ink-pdf-export';
 import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
 import { WritingEditorControls } from "../writing-embed/writing-embed";
 import { ensureThemedNativeInkSvgView } from "src/logic/utils/addEditButtonToSvgView";
@@ -175,6 +176,7 @@ export class WritingView extends TextFileView {
 
     saveFile = (inkFileData: InkFileData) => {
         this.inkFileData = inkFileData;
+		if (this.file) scheduleInkPdfPreviewRefresh(this.plugin, this.file, inkFileData.svgString);
         void this.save(false);   // Obsidian will call getViewData during this method
     }
 

--- a/src/components/shared/ink-svg-preview-theme.scss
+++ b/src/components/shared/ink-svg-preview-theme.scss
@@ -2,6 +2,17 @@
 // and native SVG leaf after ensureThemedNativeInkSvgView mounts a themed host).
 // SVG must be in the DOM (not img) for these rules to apply.
 
+// Reading mode initially renders Ink attachments as native images. Large SVGs can
+// remain in that state while the post-processor mounts a theme-aware inline SVG,
+// and a missed post-process should still be readable. Ink exports are monochrome,
+// so invert only the native image fallback in dark mode. The selector excludes
+// the React preview hosts below, which use Obsidian's exact text colour instead.
+.theme-dark .markdown-preview-view {
+	img:is([alt="InkWriting"], [alt="InkDrawing"]) {
+		filter: invert(1);
+	}
+}
+
 .ddc_ink_writing-embed-preview,
 .ddc_ink_drawing-embed-preview {
 	// !important beats baked fill="#000000" presentation attributes in saved SVGs.

--- a/src/ink-canvas/autosave-delay.ts
+++ b/src/ink-canvas/autosave-delay.ts
@@ -1,0 +1,16 @@
+export type InkPlatformFlags = {
+	isMobile?: boolean;
+	isMobileApp?: boolean;
+	isIosApp?: boolean;
+};
+
+/** Mobile WebViews need a longer quiet period before serializing large Ink SVGs. */
+export function resolveInkAutosaveDelayMs(
+	platform: InkPlatformFlags,
+	desktopDelayMs: number,
+	mobileDelayMs: number,
+): number {
+	return platform.isMobile || platform.isMobileApp || platform.isIosApp
+		? mobileDelayMs
+		: desktopDelayMs;
+}

--- a/src/ink-canvas/ink-svg-canvas.tsx
+++ b/src/ink-canvas/ink-svg-canvas.tsx
@@ -1,8 +1,6 @@
 import './ink-svg-canvas.scss';
 import React, { useEffect, useLayoutEffect, useRef, useCallback, useState, memo } from 'react';
-import { getStroke } from 'perfect-freehand';
-import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
-import { StrokeStore } from './stroke-store';
+import { StrokeStore, type StrokeStoreChange } from './stroke-store';
 import { UndoManager } from './undo-manager';
 import { panByScreenDelta, zoomAtPoint, clampZoom, fitBoundsToViewport, adjustCameraToPreservePagePointAtScreenTargets, adjustCameraToPreserveViewportCenter, screenToPage as screenToPageFn, getRightDragZoomDelta } from './camera';
 import { createPanMomentumController, createModifierWheelZoomDirectionResolver, isTrackpadWheel, type PanMomentumController } from './pan-momentum';
@@ -28,12 +26,13 @@ import { useStrokeInputTreatAs } from 'src/logic/device-settings/use-stroke-inpu
 import { useResolvedStrokeInputTreatAs } from 'src/logic/device-settings/use-resolved-stroke-input-treat-as';
 import { useBooxConnectionEnabled } from 'src/logic/device-settings/use-boox-connection-enabled';
 import { DEFAULT_SETTINGS } from 'src/types/plugin-settings';
-import { toStrokeOptions, DEFAULT_STROKE_STYLE } from './types';
+import { DEFAULT_STROKE_STYLE } from './types';
 import type { InkTool, InkStrokeStyle, CameraState, InkCanvasSnapshot, InkCanvasEditor, InkStroke } from './types';
 import type { DrawToolContext } from './tools/draw-tool';
 import type { EraseToolContext } from './tools/erase-tool';
 import type { SelectToolContext } from './tools/select-tool';
 import { InkAdaptiveGrid, INK_GRID_BOOX_ZOOM_FADE_SCALE } from './ink-adaptive-grid';
+import { getRenderedStrokeData } from './rendered-stroke-cache';
 
 type LastCanvasPointerState = {
 	clientX: number;
@@ -66,6 +65,8 @@ export interface InkSvgCanvasProps {
 	initialSnapshot?: InkCanvasSnapshot;
 	onEditorReady?: (editor: InkCanvasEditor) => void;
 	onChange?: () => void;
+	/** Pauses expensive persistence work while a pen/pointer interaction is active. */
+	onInteractionChange?: (active: boolean) => void;
 	/** Fired when a new undoable canvas command is executed (stroke, erase, move, etc.). */
 	onEmbedUndoStackPush?: () => void;
 	/** Emits whenever camera changes (pan/zoom/setCamera). */
@@ -111,6 +112,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	const pageWidth = props.pageWidth ?? WRITING_PAGE_WIDTH;
 	const writingBufferLines = props.writingBufferLines ?? 3;
 	const writingLineHeight = props.initialSnapshot?.writingLineHeight ?? WRITING_LINE_HEIGHT;
+	const contentMaxYRef = useRef(0);
 
 	const canvasWrapperRef = useRef<HTMLDivElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -124,6 +126,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		const contentHeight = strokes.length > 0
 			? computeApproxContentMaxY(strokes)
 			: 0;
+		contentMaxYRef.current = contentHeight;
 		return cropWritingStrokeHeightInvitingly(contentHeight, writingBufferLines, writingLineHeight);
 	}
 
@@ -180,6 +183,8 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	gridEnabledRef.current = gridEnabled;
 	const onChangeRef = useRef(props.onChange);
 	onChangeRef.current = props.onChange;
+	const onInteractionChangeRef = useRef(props.onInteractionChange);
+	onInteractionChangeRef.current = props.onInteractionChange;
 	const onEmbedUndoStackPushRef = useRef(props.onEmbedUndoStackPush);
 	onEmbedUndoStackPushRef.current = props.onEmbedUndoStackPush;
 	const setGridEnabledHandlerRef = useRef<(enabled: boolean) => void>(() => {});
@@ -306,21 +311,29 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	// Subscribe to store changes to re-render strokes
 	useEffect(() => {
-		const unsubStore = storeRef.current.subscribe(() => {
-			// Invalidate cull bounds + path `d` — points/style may have changed; store still holds every stroke.
-			strokeBoundsCacheRef.current.clear();
-			strokePathDCacheRef.current.clear();
+		const unsubStore = storeRef.current.subscribe((change) => {
+			// Only invalidate cache entries touched by this mutation.
+			invalidateStrokeCaches(change);
 			forceRender(n => n + 1);
 			props.onChange?.();
 
 			if (writingMode) {
-				const allStrokes = storeRef.current.getAll();
+				if (change.type === 'add' || change.type === 'addMany') {
+					for (const id of change.ids) {
+						const stroke = storeRef.current.getById(id);
+						if (!stroke) continue;
+						const bounds = computeApproxStrokePageBounds(stroke);
+						strokeBoundsCacheRef.current.set(id, bounds);
+						if (bounds.maxY > contentMaxYRef.current) contentMaxYRef.current = bounds.maxY;
+					}
+				} else if (change.type === 'clear') {
+					contentMaxYRef.current = 0;
+				} else {
+					contentMaxYRef.current = computeApproxContentMaxY(storeRef.current.getAll());
+				}
 				const lh = props.initialSnapshot?.writingLineHeight ?? WRITING_LINE_HEIGHT;
-				const contentHeight = allStrokes.length > 0
-					? computeApproxContentMaxY(allStrokes)
-					: 0;
 				const candidateHeight = cropWritingStrokeHeightInvitingly(
-					contentHeight,
+					contentMaxYRef.current,
 					writingBufferLines,
 					lh,
 				);
@@ -335,6 +348,20 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		});
 		return () => { unsubStore(); unsubUndo(); };
 	}, []);  
+
+	function invalidateStrokeCaches(change: StrokeStoreChange): void {
+		if (change.type === 'clear' || change.type === 'replaceAll') {
+			strokeBoundsCacheRef.current.clear();
+			strokePathDCacheRef.current.clear();
+			return;
+		}
+
+		for (const id of change.ids) {
+			strokeBoundsCacheRef.current.delete(id);
+			// Moving a stroke only changes its transform; its path data stays valid.
+			if (change.type !== 'updateOffsets') strokePathDCacheRef.current.delete(id);
+		}
+	}
 
 	// Re-cull when the note scroller or window moves the canvas on/off screen (embeds + dedicated).
 	useEffect(() => {
@@ -725,6 +752,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		// Touch input: two-finger gestures are handled by the native touch listener.
 		// Single-finger touch is ignored unless finger drawing is active.
 		if (e.pointerType === 'touch' && !isFingerDrawingActiveRef.current) return;
+		onInteractionChangeRef.current?.(true);
 
 		recordCanvasPointer(e);
 		isPointerOverCanvasRef.current = true;
@@ -847,6 +875,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	const handlePointerUp = useCallback((e: React.PointerEvent) => {
 		if (e.pointerType === 'touch' && !isFingerDrawingActiveRef.current) return;
+		onInteractionChangeRef.current?.(false);
 
 		recordCanvasPointer(e);
 
@@ -878,6 +907,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	const handlePointerCancel = useCallback((e: React.PointerEvent) => {
 		if (e.pointerType === 'touch' && !isFingerDrawingActiveRef.current) return;
+		onInteractionChangeRef.current?.(false);
 
 		recordCanvasPointer(e);
 
@@ -1303,8 +1333,7 @@ const StrokePath = memo(function StrokePath(props: StrokePathProps): React.JSX.E
 	// cache clear + remount) reuse `d` when the id is still populated; offset is transform-only.
 	let d = pathDCache.get(stroke.id);
 	if (d === undefined) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		d = getSvgPathFromStroke(outlinePoints);
+		d = getRenderedStrokeData(stroke).pathD;
 		pathDCache.set(stroke.id, d);
 	}
 

--- a/src/ink-canvas/rendered-stroke-cache.ts
+++ b/src/ink-canvas/rendered-stroke-cache.ts
@@ -1,0 +1,48 @@
+import { getStroke } from 'perfect-freehand';
+import type { InkStroke } from './types';
+import { toStrokeOptions } from './types';
+import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
+
+export type RenderedStrokeBounds = {
+	minX: number;
+	minY: number;
+	maxX: number;
+	maxY: number;
+};
+
+export type RenderedStrokeData = {
+	pathD: string;
+	bounds: RenderedStrokeBounds;
+};
+
+// Strokes are immutable in normal use. A WeakMap lets editor rendering and
+// autosave share the expensive perfect-freehand outline without retaining
+// deleted strokes.
+const renderedStrokeCache = new WeakMap<InkStroke, RenderedStrokeData>();
+
+export function getRenderedStrokeData(stroke: InkStroke): RenderedStrokeData {
+	const cached = renderedStrokeCache.get(stroke);
+	if (cached) return cached;
+
+	const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
+	let minX = Infinity;
+	let minY = Infinity;
+	let maxX = -Infinity;
+	let maxY = -Infinity;
+
+	for (const [x, y] of outlinePoints) {
+		if (x < minX) minX = x;
+		if (y < minY) minY = y;
+		if (x > maxX) maxX = x;
+		if (y > maxY) maxY = y;
+	}
+
+	const data: RenderedStrokeData = {
+		pathD: getSvgPathFromStroke(outlinePoints),
+		bounds: Number.isFinite(minX)
+			? { minX, minY, maxX, maxY }
+			: { minX: 0, minY: 0, maxX: 0, maxY: 0 },
+	};
+	renderedStrokeCache.set(stroke, data);
+	return data;
+}

--- a/src/ink-canvas/stroke-store.ts
+++ b/src/ink-canvas/stroke-store.ts
@@ -3,7 +3,11 @@ import type { InkStroke } from './types';
 ///////////////////////////
 ///////////////////////////
 
-export type StrokeStoreListener = () => void;
+export type StrokeStoreChange =
+	| { type: 'add' | 'addMany' | 'remove' | 'updateOffsets'; ids: string[] }
+	| { type: 'clear' | 'replaceAll'; ids: [] };
+
+export type StrokeStoreListener = (change: StrokeStoreChange) => void;
 
 /**
  * Reactive store for ink strokes. Maintains an ordered list of strokes and
@@ -20,16 +24,16 @@ export class StrokeStore {
 		return () => { this.listeners.delete(listener); };
 	}
 
-	private notify(): void {
+	private notify(change: StrokeStoreChange): void {
 		for (const listener of this.listeners) {
-			listener();
+			listener(change);
 		}
 	}
 
 	add(stroke: InkStroke): void {
 		this.strokes.set(stroke.id, stroke);
 		this.insertionOrder.push(stroke.id);
-		this.notify();
+		this.notify({ type: 'add', ids: [stroke.id] });
 	}
 
 	addMany(strokesArr: InkStroke[]): void {
@@ -37,7 +41,7 @@ export class StrokeStore {
 			this.strokes.set(stroke.id, stroke);
 			this.insertionOrder.push(stroke.id);
 		}
-		this.notify();
+		this.notify({ type: 'addMany', ids: strokesArr.map((stroke) => stroke.id) });
 	}
 
 	remove(ids: string[]): void {
@@ -46,7 +50,7 @@ export class StrokeStore {
 			this.strokes.delete(id);
 		}
 		this.insertionOrder = this.insertionOrder.filter(id => !idSet.has(id));
-		this.notify();
+		this.notify({ type: 'remove', ids: [...ids] });
 	}
 
 	/** Update the offset of one or more strokes (used by the select-and-move tool). */
@@ -57,7 +61,7 @@ export class StrokeStore {
 				this.strokes.set(id, { ...stroke, offset });
 			}
 		}
-		this.notify();
+		this.notify({ type: 'updateOffsets', ids: Array.from(offsets.keys()) });
 	}
 
 	getById(id: string): InkStroke | undefined {
@@ -82,7 +86,7 @@ export class StrokeStore {
 	clear(): void {
 		this.strokes.clear();
 		this.insertionOrder = [];
-		this.notify();
+		this.notify({ type: 'clear', ids: [] });
 	}
 
 	/** Replace all content with the given strokes (used for snapshot restore). */
@@ -93,6 +97,6 @@ export class StrokeStore {
 			this.strokes.set(stroke.id, stroke);
 			this.insertionOrder.push(stroke.id);
 		}
-		this.notify();
+		this.notify({ type: 'replaceAll', ids: [] });
 	}
 }

--- a/src/ink-canvas/svg-export.ts
+++ b/src/ink-canvas/svg-export.ts
@@ -107,6 +107,13 @@ function renderStrokePathsAndBounds(strokes: InkStroke[]): {
 	pathsMarkup: string;
 	bounds: StrokeBounds;
 } {
+	if (strokes.length === 0) {
+		return {
+			pathsMarkup: '',
+			bounds: { minX: 0, minY: 0, maxX: 0, maxY: 0, width: 0, height: 0 },
+		};
+	}
+
 	let minX = Infinity;
 	let minY = Infinity;
 	let maxX = -Infinity;

--- a/src/ink-canvas/svg-export.ts
+++ b/src/ink-canvas/svg-export.ts
@@ -1,4 +1,3 @@
-import { getStroke } from 'perfect-freehand';
 import {
 	DEFAULT_CONTENT_COLOUR_PRIMARY_STROKE,
 	DEFAULT_CONTENT_COLOUR_WRITING_LINE,
@@ -6,9 +5,8 @@ import {
 	INK_SVG_WRITING_LINE_CLASS,
 } from 'src/default-content-colours';
 import { INK_CANVAS_FORMAT_VERSION, WRITING_LINE_HEIGHT, WRITING_MIN_PAGE_HEIGHT } from 'src/constants';
-import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
 import type { InkStroke, InkCanvasSnapshot } from './types';
-import { toStrokeOptions } from './types';
+import { getRenderedStrokeData } from './rendered-stroke-cache';
 ///////////////////////////
 ///////////////////////////
 
@@ -26,7 +24,8 @@ export function renderStrokesToSvg(
 		return buildSvgString('', '0 0 1 1', snapshotJson);
 	}
 
-	const bounds = computeStrokesBounds(strokes);
+	const rendered = renderStrokePathsAndBounds(strokes);
+	const bounds = rendered.bounds;
 	const viewBox = [
 		bounds.minX - padding,
 		bounds.minY - padding,
@@ -34,14 +33,7 @@ export function renderStrokesToSvg(
 		bounds.height + padding * 2,
 	].join(' ');
 
-	let pathsMarkup = '';
-	for (const stroke of strokes) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		const d = getSvgPathFromStroke(outlinePoints);
-		pathsMarkup += buildStrokePathMarkup(d, stroke.offset.x, stroke.offset.y);
-	}
-
-	return buildSvgString(pathsMarkup, viewBox, snapshotJson);
+	return buildSvgString(rendered.pathsMarkup, viewBox, snapshotJson);
 }
 
 /**
@@ -55,10 +47,10 @@ export function renderWritingStrokesToSvg(
 	padding: number = 0,
 ): string {
 	const lineHeight = snapshot.writingLineHeight ?? WRITING_LINE_HEIGHT;
+	const rendered = renderStrokePathsAndBounds(strokes);
 	let height = WRITING_MIN_PAGE_HEIGHT;
 	if (strokes.length > 0) {
-		const bounds = computeStrokesBounds(strokes);
-		const numFilledLines = Math.ceil((bounds.maxY + padding) / lineHeight);
+		const numFilledLines = Math.ceil((rendered.bounds.maxY + padding) / lineHeight);
 		height = Math.max((numFilledLines + 0.5) * lineHeight, WRITING_MIN_PAGE_HEIGHT);
 	}
 
@@ -70,15 +62,8 @@ export function renderWritingStrokesToSvg(
 		guideMarkup += `<line x1="${margin}" y1="${y}" x2="${pageWidth - margin}" y2="${y}" stroke="${DEFAULT_CONTENT_COLOUR_WRITING_LINE}" stroke-opacity="0.5" class="${INK_SVG_WRITING_LINE_CLASS}" />\n`;
 	}
 
-	let pathsMarkup = '';
-	for (const stroke of strokes) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		const d = getSvgPathFromStroke(outlinePoints);
-		pathsMarkup += buildStrokePathMarkup(d, stroke.offset.x, stroke.offset.y);
-	}
-
 	const viewBox = `0 0 ${pageWidth} ${height}`;
-	return buildSvgString(guideMarkup + pathsMarkup, viewBox, snapshot);
+	return buildSvgString(guideMarkup + rendered.pathsMarkup, viewBox, snapshot);
 }
 
 
@@ -104,19 +89,47 @@ function buildSvgString(
 	return [
 		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}">`,
 		`<metadata>`,
-		`<ink-canvas version="${INK_CANVAS_FORMAT_VERSION}">${escapeXml(metadataJson)}</ink-canvas>`,
+		`<ink-canvas version="${INK_CANVAS_FORMAT_VERSION}">${escapeXmlText(metadataJson)}</ink-canvas>`,
 		`</metadata>`,
 		pathsMarkup,
 		`</svg>`,
 	].join('\n');
 }
 
-function escapeXml(str: string): string {
+function escapeXmlText(str: string): string {
 	return str
 		.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
+		.replace(/>/g, '&gt;');
+}
+
+function renderStrokePathsAndBounds(strokes: InkStroke[]): {
+	pathsMarkup: string;
+	bounds: StrokeBounds;
+} {
+	let minX = Infinity;
+	let minY = Infinity;
+	let maxX = -Infinity;
+	let maxY = -Infinity;
+	let pathsMarkup = '';
+
+	for (const stroke of strokes) {
+		const rendered = getRenderedStrokeData(stroke);
+		const strokeMinX = rendered.bounds.minX + stroke.offset.x;
+		const strokeMinY = rendered.bounds.minY + stroke.offset.y;
+		const strokeMaxX = rendered.bounds.maxX + stroke.offset.x;
+		const strokeMaxY = rendered.bounds.maxY + stroke.offset.y;
+		if (strokeMinX < minX) minX = strokeMinX;
+		if (strokeMinY < minY) minY = strokeMinY;
+		if (strokeMaxX > maxX) maxX = strokeMaxX;
+		if (strokeMaxY > maxY) maxY = strokeMaxY;
+		pathsMarkup += buildStrokePathMarkup(rendered.pathD, stroke.offset.x, stroke.offset.y);
+	}
+
+	return {
+		pathsMarkup,
+		bounds: { minX, minY, maxX, maxY, width: maxX - minX, height: maxY - minY },
+	};
 }
 
 
@@ -139,17 +152,15 @@ export function computeStrokesBounds(strokes: InkStroke[]): StrokeBounds {
 	let maxY = -Infinity;
 
 	for (const stroke of strokes) {
-		// Compute the outline to get the true rendered bounds
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-
-		for (const [px, py] of outlinePoints) {
-			const x = px + stroke.offset.x;
-			const y = py + stroke.offset.y;
-			if (x < minX) minX = x;
-			if (y < minY) minY = y;
-			if (x > maxX) maxX = x;
-			if (y > maxY) maxY = y;
-		}
+		const rendered = getRenderedStrokeData(stroke);
+		const strokeMinX = rendered.bounds.minX + stroke.offset.x;
+		const strokeMinY = rendered.bounds.minY + stroke.offset.y;
+		const strokeMaxX = rendered.bounds.maxX + stroke.offset.x;
+		const strokeMaxY = rendered.bounds.maxY + stroke.offset.y;
+		if (strokeMinX < minX) minX = strokeMinX;
+		if (strokeMinY < minY) minY = strokeMinY;
+		if (strokeMaxX > maxX) maxX = strokeMaxX;
+		if (strokeMaxY > maxY) maxY = strokeMaxY;
 	}
 
 	return {

--- a/src/logic/utils/convert-file-embeds.ts
+++ b/src/logic/utils/convert-file-embeds.ts
@@ -9,6 +9,7 @@ import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
 import { buildDrawingEmbedSettingsFromStrokes } from "src/logic/utils/build-drawing-embed-settings-from-file";
 import { parseSvgViewBoxAspectRatio } from "src/logic/utils/writing-embed-aspect-ratio";
 import type { EmbedSettings } from "src/types/embed-settings";
+import { getInkPdfPreviewPath } from 'src/logic/utils/ink-pdf-export';
 // View type strings (avoid importing from view modules to prevent heavy deps in tests)
 const INK_WRITING_VIEW_TYPE = "ink_writing-view";
 const INK_DRAWING_VIEW_TYPE = "ink_drawing-view";
@@ -65,9 +66,10 @@ function buildFileEmbedPattern(
 	global = false,
 ): RegExp {
 	const escapedPath = svgFilePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const escapedPreviewPath = getInkPdfPreviewPath(svgFilePath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	const altText = embedType === 'inkWriting' ? 'InkWriting' : 'InkDrawing';
 	return new RegExp(
-		` !\\[${altText}\\]\\(<${escapedPath}>\\)`,
+		` !\\[${altText}\\]\\(<(?:${escapedPath}|${escapedPreviewPath})>\\)`,
 		global ? 'g' : undefined,
 	);
 }
@@ -159,10 +161,11 @@ export async function removeAllEmbedsOfFileFromNote(
 	let content = await vault.read(note);
 
 	const escapedPath = svgFilePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const escapedPreviewPath = getInkPdfPreviewPath(svgFilePath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	const altText = embedType === 'inkWriting' ? 'InkWriting' : 'InkDrawing';
 	// Match the full embed line (everything up to and including the newline)
 	const lineRegex = new RegExp(
-		` !\\[${altText}\\]\\(<${escapedPath}>\\)[^\\n]*\\r?\\n?`,
+		` !\\[${altText}\\]\\(<(?:${escapedPath}|${escapedPreviewPath})>\\)[^\\n]*\\r?\\n?`,
 		'g',
 	);
 
@@ -232,10 +235,11 @@ export async function updateEmbedInNote(
 	let content = await vault.read(note);
 
 	const escapedOldPath = oldSvgPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const escapedOldPreviewPath = getInkPdfPreviewPath(oldSvgPath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	const fromAlt = toType === 'inkWriting' ? 'InkDrawing' : 'InkWriting';
 	// Match the full embed line (everything up to end of line)
 	const lineRegex = new RegExp(
-		` !\\[${fromAlt}\\]\\(<${escapedOldPath}>\\)[^\n]*`,
+		` !\\[${fromAlt}\\]\\(<(?:${escapedOldPath}|${escapedOldPreviewPath})>\\)[^\n]*`,
 		'g',
 	);
 

--- a/src/logic/utils/detect-reading-mode-ink-embed.ts
+++ b/src/logic/utils/detect-reading-mode-ink-embed.ts
@@ -2,6 +2,7 @@ import { App, normalizePath, TFile } from 'obsidian';
 import { parseSettingsFromUrl } from 'src/components/formats/current/utils/parse-settings-from-url';
 import { EmbedSettings } from 'src/types/embed-settings';
 import { InkEmbedKind } from './embed';
+import { getInkSourcePathFromEmbedPath } from './ink-pdf-export';
 
 export const INK_READING_PROCESSED_ATTR = 'data-ink-reading-processed';
 /** Set while a MarkdownRenderChild is mounted into the host. */
@@ -49,8 +50,9 @@ export function findReadingModeInkEmbedCandidates(
 			const editLinkEl = findInkEditLinkForMarker(embedMarkerEl, editLinkFragment);
 			if (!editLinkEl) return;
 
-			const partialEmbedFilepath = extractPartialEmbedFilepath(embedMarkerEl);
-			if (!partialEmbedFilepath) return;
+			const markerFilepath = extractPartialEmbedFilepath(embedMarkerEl);
+			if (!markerFilepath) return;
+			const partialEmbedFilepath = getInkSourcePathFromEmbedPath(markerFilepath);
 
 			const settingsHref = editLinkEl.getAttribute('href') ?? '';
 			const { embedSettings, isPendingPaste } = parseSettingsFromUrl(settingsHref);

--- a/src/logic/utils/ink-file-has-strokes.ts
+++ b/src/logic/utils/ink-file-has-strokes.ts
@@ -17,7 +17,37 @@ export function getInkStrokesFromSvg(svgString: string): InkStroke[] {
 }
 
 export function inkFileHasStrokes(svgString: string): boolean {
+	const inkCanvasResult = sniffInkCanvasHasStrokes(svgString);
+	if (inkCanvasResult !== null) return inkCanvasResult;
+
 	return getInkStrokesFromSvg(svgString).length > 0;
+}
+
+/**
+ * Read only the `strokes` array opener from current ink-canvas metadata.
+ * This avoids XML parsing and JSON-decoding every point in multi-megabyte files
+ * when a locked preview only needs to distinguish an empty canvas.
+ */
+export function sniffInkCanvasHasStrokes(svgString: string): boolean | null {
+	const inkCanvasStart = svgString.search(/<ink-canvas\b/i);
+	if (inkCanvasStart === -1) return null;
+
+	const inkCanvasEnd = svgString.indexOf('</ink-canvas>', inkCanvasStart);
+	if (inkCanvasEnd === -1) return null;
+
+	const strokesKey = svgString.indexOf('"strokes"', inkCanvasStart);
+	if (strokesKey === -1 || strokesKey >= inkCanvasEnd) return null;
+
+	const arrayStart = svgString.indexOf('[', strokesKey + '"strokes"'.length);
+	if (arrayStart === -1 || arrayStart >= inkCanvasEnd) return null;
+
+	let firstValueIndex = arrayStart + 1;
+	while (firstValueIndex < inkCanvasEnd && /\s/.test(svgString[firstValueIndex])) {
+		firstValueIndex += 1;
+	}
+
+	if (firstValueIndex >= inkCanvasEnd) return null;
+	return svgString[firstValueIndex] !== ']';
 }
 
 /** When locked and empty, show frame/lines/background regardless of the matching setting. */

--- a/src/logic/utils/ink-pdf-export.ts
+++ b/src/logic/utils/ink-pdf-export.ts
@@ -1,0 +1,99 @@
+import { normalizePath, TFile } from 'obsidian';
+import type InkPlugin from 'src/main';
+import { getPreviewFileVaultPath } from './getPreviewFileVaultPath';
+import { savePngExport } from './savePngExport';
+import { svgToPngDataUri } from './screenshots';
+
+const PDF_PREVIEW_REFRESH_DELAY_MS = 1200;
+let nativePdfPreviewUntil = 0;
+
+type PendingPreviewRefresh = {
+	timer: number;
+	plugin: InkPlugin;
+	file: TFile;
+	svgString: string;
+};
+
+const pendingPreviewRefreshes = new Map<string, PendingPreviewRefresh>();
+
+export function allowNativeInkPdfPreviewsForNextExport(timeoutMs = 120000): void {
+	nativePdfPreviewUntil = Date.now() + timeoutMs;
+}
+
+export function shouldUseNativeInkPdfPreviews(): boolean {
+	return Date.now() < nativePdfPreviewUntil;
+}
+
+export function getInkPdfPreviewPath(svgPath: string): string {
+	return normalizePath(svgPath.replace(/\.svg$/i, '.png'));
+}
+
+/** PNG markers use the same basename as their editable SVG attachment. */
+export function getInkSourcePathFromEmbedPath(embedPath: string): string {
+	return normalizePath(embedPath.replace(/\.png$/i, '.svg'));
+}
+
+export function isInkPdfPreviewPath(path: string): boolean {
+	return /\.png$/i.test(path);
+}
+
+/**
+ * Rasterize an Ink SVG once for Obsidian's PDF exporter, which omits local SVG
+ * attachments. The SVG remains the editable source; this PNG is only a preview.
+ */
+export async function writeInkPdfPreview(
+	plugin: InkPlugin,
+	file: TFile,
+	svgString?: string,
+): Promise<string> {
+	const svg = svgString ?? await plugin.app.vault.cachedRead(file);
+	const dimensions = readSvgDimensions(svg);
+	if (!dimensions) throw new Error(`Ink SVG has no valid viewBox: ${file.path}`);
+
+	const dataUri = await svgToPngDataUri({ ...dimensions, svg });
+	if (!dataUri) throw new Error(`Could not render PDF preview: ${file.path}`);
+
+	await savePngExport(plugin, dataUri, file);
+	return getInkPdfPreviewPath(file.path);
+}
+
+/**
+ * Coalesce autosaves and do no work for legacy SVG-only embeds. Once a PNG
+ * companion exists, its refresh runs after the pen has been idle for a moment.
+ */
+export function scheduleInkPdfPreviewRefresh(
+	plugin: InkPlugin,
+	file: TFile,
+	svgString: string,
+): void {
+	const previewPath = getInkPdfPreviewPath(file.path);
+	const previewFile = plugin.app.vault.getAbstractFileByPath(previewPath);
+	if (!(previewFile instanceof TFile)) return;
+
+	const previous = pendingPreviewRefreshes.get(file.path);
+	if (previous) window.clearTimeout(previous.timer);
+
+	const pending: PendingPreviewRefresh = {
+		plugin,
+		file,
+		svgString,
+		timer: window.setTimeout(() => {
+			pendingPreviewRefreshes.delete(file.path);
+			void writeInkPdfPreview(plugin, file, svgString).catch((error) => {
+				console.error('Unable to refresh Ink PDF preview', error);
+			});
+		}, PDF_PREVIEW_REFRESH_DELAY_MS),
+	};
+	pendingPreviewRefreshes.set(file.path, pending);
+}
+
+function readSvgDimensions(svg: string): { width: number; height: number } | null {
+	const match = svg.match(/<svg\b[^>]*\bviewBox\s*=\s*["']([^"']+)["']/i);
+	if (!match) return null;
+	const parts = match[1].trim().split(/[\s,]+/).map(Number);
+	if (parts.length < 4) return null;
+	const width = parts[2];
+	const height = parts[3];
+	if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
+	return { width, height };
+}

--- a/src/logic/utils/screenshots.ts
+++ b/src/logic/utils/screenshots.ts
@@ -3,24 +3,18 @@ import { Canvg } from 'canvg';
 //////////
 //////////
 
-export async function svgToPngDataUri(svgObj: {	height: number,	width: number, svg: string, }): Promise<string | null> {
+export async function svgToPngDataUri(svgObj: { height: number; width: number; svg: string }): Promise<string | null> {
 	try {
-		// Extract width and height from the SVG element
-		let width = svgObj.width;
-		let height = svgObj.height;
-		
-        // Scale up or down
-		if (width > 1500 || height > 2000) {
-			while(width > 1500) {
-				width /= 2;
-				height /= 2;
-			}
-		} else if(width < 500) {
-			while(width < 500) {
-				width *= 2;
-				height *= 2;
-			}
-		} 
+		const sourceWidth = Math.max(1, svgObj.width);
+		const sourceHeight = Math.max(1, svgObj.height);
+		// Two device pixels per typical 700px note column keeps handwriting crisp in
+		// PDF without retaining the often much larger SVG coordinate dimensions.
+		const widthScale = Math.min(1, 1400 / sourceWidth);
+		const heightScale = Math.min(1, 16000 / sourceHeight);
+		const upscale = sourceWidth < 600 ? 600 / sourceWidth : 1;
+		const scale = Math.min(upscale, widthScale, heightScale);
+		const width = Math.max(1, Math.round(sourceWidth * scale));
+		const height = Math.max(1, Math.round(sourceHeight * scale));
 		
 		// Set canvas dimensions
 		const canvas = activeDocument.createElement('canvas');
@@ -35,15 +29,13 @@ export async function svgToPngDataUri(svgObj: {	height: number,	width: number, s
 		// Render SVG onto canvas
 		const svgStr = svgObj.svg;
 		const canvgRenderer = await Canvg.from(ctx, svgStr);
-        canvgRenderer.resize(width, height, 'xMidYMid meet')
-		canvgRenderer.start();
+		canvgRenderer.resize(width, height, 'xMidYMid meet');
+		await canvgRenderer.render();
 		
 		// Convert canvas to PNG data URI with transparent background
-		// @ts-ignore
-		const dataURL = canvas.toDataURL('image/png', {alpha: true});
+		const dataURL = canvas.toDataURL('image/png');
 		
 		// Remove temporary canvas element
-		canvgRenderer.stop();
 		canvas.remove();
 
 		return dataURL;

--- a/src/logic/utils/svg-edit-button.scss
+++ b/src/logic/utils/svg-edit-button.scss
@@ -1,5 +1,3 @@
-@use '../../components/shared/ink-svg-preview-theme';
-
 .ddc_ink_svg-view-content--anchor {
     position: relative;
 }

--- a/src/logic/utils/use-ink-file-has-strokes.ts
+++ b/src/logic/utils/use-ink-file-has-strokes.ts
@@ -8,6 +8,7 @@ import { inkFileHasStrokes } from 'src/logic/utils/ink-file-has-strokes';
  */
 export function useInkFileHasStrokes(file: TFile | null, vault: Vault): boolean | null {
 	const [hasStrokes, setHasStrokes] = useState<boolean | null>(null);
+	const fileMtime = file?.stat.mtime;
 
 	useEffect(() => {
 		if (!file) {
@@ -20,7 +21,7 @@ export function useInkFileHasStrokes(file: TFile | null, vault: Vault): boolean 
 
 		async function refresh() {
 			try {
-				const svgString = await vault.read(inkFile);
+				const svgString = await vault.cachedRead(inkFile);
 				if (!cancelled) {
 					setHasStrokes(inkFileHasStrokes(svgString));
 				}
@@ -33,18 +34,13 @@ export function useInkFileHasStrokes(file: TFile | null, vault: Vault): boolean 
 
 		void refresh();
 
-		const onModify = (modifiedFile: TFile) => {
-			if (modifiedFile.path !== inkFile.path) return;
-			void refresh();
-		};
-		const eventRef = vault.on('modify', onModify);
-
 		return () => {
 			cancelled = true;
-			// @ts-ignore - offref exists in Obsidian API
-			vault.offref(eventRef);
 		};
-	}, [file, vault]);
+	// The preview component already subscribes to vault modifications and changes
+	// its mtime-busted source URL. Reuse that render instead of registering a
+	// second listener for every Ink embed.
+	}, [file, fileMtime, vault]);
 
 	return hasStrokes;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import './ddc-library/settings-styles.scss';
+import './components/shared/ink-svg-preview-theme.scss';
 import { App, Editor, Notice, Platform, Plugin, addIcon } from 'obsidian';
 import { DEFAULT_SETTINGS, PluginSettings } from 'src/types/plugin-settings';
 import { registerSettingsTab } from './components/dom-components/tabs/settings-tab/settings-tab';

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import {
 	resetFingerDrawingToDefault,
 	setBooxConnectionEnabled,
 } from 'src/logic/device-settings/device-settings';
+import { registerPrepareInkPdfExportCommand } from 'src/commands/prepare-ink-pdf-export';
 
 ////////
 ////////
@@ -167,6 +168,7 @@ export default class InkPlugin extends Plugin {
 			this.registerEditorExtension([inkEmbedsExtension()]);
 			registerPasteEmbedHandler(this);
 			registerReadingModeInkEmbeds(this);
+			registerPrepareInkPdfExportCommand(this);
 		}
 
 		registerSettingsTab(this);

--- a/tests/components/formats/current/drawing/DrawingEmbedPreview.test.tsx
+++ b/tests/components/formats/current/drawing/DrawingEmbedPreview.test.tsx
@@ -16,7 +16,7 @@ jest.mock('src/stores/global-store', () => ({
 			app: {
 				vault: {
 					getResourcePath: () => '/vault/drawing.svg',
-					read: (...args: unknown[]) => mockVaultRead(...args),
+					cachedRead: (...args: unknown[]) => mockVaultRead(...args),
 					on: jest.fn(() => jest.fn()),
 					offref: jest.fn(),
 				},

--- a/tests/components/formats/current/utils/BuildFileStr.test.ts
+++ b/tests/components/formats/current/utils/BuildFileStr.test.ts
@@ -110,6 +110,19 @@ describe('buildFileStr — ink-canvas serialization', () => {
 		expect(result).not.toContain('stale');
 	});
 
+	test('removes every stale metadata block before inserting the current snapshot', () => {
+		const data = makeInkCanvasFileData();
+		data.svgString = data.svgString.replace(
+			'<path id="kept"/>',
+			'<metadata><ink-canvas>also-stale</ink-canvas></metadata><path id="kept"/>',
+		);
+
+		const result = buildFileStr(data);
+		expect(result.match(/<metadata\b/g)).toHaveLength(1);
+		expect(result).not.toContain('also-stale');
+		expect(result).toContain('<path id="kept"/>');
+	});
+
 	test('uses compact XML-safe JSON that survives a round trip', () => {
 		const result = buildFileStr(makeInkCanvasFileData());
 		const parsed = extractInkJsonFromSvg(result);

--- a/tests/components/formats/current/utils/BuildFileStr.test.ts
+++ b/tests/components/formats/current/utils/BuildFileStr.test.ts
@@ -3,6 +3,7 @@ import { buildFileStr } from 'src/components/formats/current/utils/buildFileStr'
 import { extractInkJsonFromSvg } from 'src/logic/utils/extractInkJsonFromSvg';
 import { InkFileData } from 'src/components/formats/current/types/file-data';
 import { PLUGIN_VERSION, TLDRAW_VERSION } from 'src/constants';
+import { DEFAULT_STROKE_STYLE, type InkCanvasSnapshot } from 'src/ink-canvas/types';
 
 ////////
 ////////
@@ -34,6 +35,30 @@ function makeDrawingFileData(): InkFileData {
 		},
 		tldraw: minimalSnapshot,
 		svgString: '<svg xmlns="http://www.w3.org/2000/svg"><defs/></svg>',
+	};
+}
+
+function makeInkCanvasFileData(): InkFileData {
+	const inkCanvas: InkCanvasSnapshot = {
+		version: 1,
+		strokes: [{
+			id: 'stroke<&',
+			points: [[0, 0, 0.5], [10, 10, 0.7]],
+			style: { ...DEFAULT_STROKE_STYLE },
+			offset: { x: 0, y: 0 },
+		}],
+		gridEnabled: false,
+		writingLineHeight: 150,
+	};
+	return {
+		meta: {
+			pluginVersion: PLUGIN_VERSION,
+			tldrawVersion: '',
+			fileType: 'inkWriting',
+		},
+		tldraw: minimalSnapshot,
+		inkCanvas,
+		svgString: '<svg xmlns="http://www.w3.org/2000/svg"><metadata><ink-canvas>stale</ink-canvas></metadata><path id="kept"/></svg>',
 	};
 }
 
@@ -73,6 +98,27 @@ describe('buildFileStr — writing-line-height attribute', () => {
 	test('always includes the tldraw element', () => {
 		const result = buildFileStr(makeWritingFileData(150));
 		expect(result).toContain('<tldraw');
+	});
+});
+
+describe('buildFileStr — ink-canvas serialization', () => {
+	test('replaces only metadata and keeps rendered SVG markup intact', () => {
+		const result = buildFileStr(makeInkCanvasFileData());
+
+		expect(result.match(/<metadata\b/g)).toHaveLength(1);
+		expect(result).toContain('<path id="kept"/>');
+		expect(result).not.toContain('stale');
+	});
+
+	test('uses compact XML-safe JSON that survives a round trip', () => {
+		const result = buildFileStr(makeInkCanvasFileData());
+		const parsed = extractInkJsonFromSvg(result);
+
+		expect(result).toContain('"version":1');
+		expect(result).not.toContain('\n  "version"');
+		expect(result).toContain('stroke&lt;&amp;');
+		expect(parsed?.inkCanvas?.strokes[0].id).toBe('stroke<&');
+		expect(parsed?.inkCanvas?.writingLineHeight).toBe(150);
 	});
 });
 

--- a/tests/components/formats/current/writing/WritingEmbedPreview.test.tsx
+++ b/tests/components/formats/current/writing/WritingEmbedPreview.test.tsx
@@ -38,7 +38,7 @@ const makePlugin = (vaultRead: jest.Mock) => ({
 	app: {
 		vault: {
 			getResourcePath: jest.fn(() => '/vault/writing.svg'),
-			read: vaultRead,
+			cachedRead: vaultRead,
 			on: jest.fn(() => jest.fn()),
 			offref: jest.fn(),
 		},

--- a/tests/e2e/reading-mode.e2e.ts
+++ b/tests/e2e/reading-mode.e2e.ts
@@ -90,7 +90,7 @@ describe("Reading mode ink embeds", function () {
 
 		expect(fillsByTheme).not.toBeNull();
 		expect(fillsByTheme!.lightFill).not.toBe(fillsByTheme!.darkFill);
-		// Baked SVG uses #000000 — themed display must not stay hardcoded black in both themes.
-		expect(fillsByTheme!.lightFill === "rgb(0, 0, 0)" && fillsByTheme!.darkFill === "rgb(0, 0, 0)").toBe(false);
+		// Baked SVG uses #000000; dark Reading mode must override it to a visible colour.
+		expect(fillsByTheme!.darkFill).not.toBe("rgb(0, 0, 0)");
 	});
 });

--- a/tests/ink-canvas/autosave-delay.test.ts
+++ b/tests/ink-canvas/autosave-delay.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from '@jest/globals';
+import { resolveInkAutosaveDelayMs } from 'src/ink-canvas/autosave-delay';
+
+describe('resolveInkAutosaveDelayMs', () => {
+	test('keeps the short quiet period on desktop', () => {
+		expect(resolveInkAutosaveDelayMs({}, 500, 2000)).toBe(500);
+	});
+
+	test.each([
+		{ isMobile: true },
+		{ isMobileApp: true },
+		{ isIosApp: true },
+	])('uses the longer quiet period for mobile platform flag %#', (platform) => {
+		expect(resolveInkAutosaveDelayMs(platform, 500, 2000)).toBe(2000);
+	});
+});

--- a/tests/ink-canvas/rendered-stroke-cache.test.ts
+++ b/tests/ink-canvas/rendered-stroke-cache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from '@jest/globals';
+import { getRenderedStrokeData } from 'src/ink-canvas/rendered-stroke-cache';
+import type { InkStroke } from 'src/ink-canvas/types';
+import { DEFAULT_STROKE_STYLE } from 'src/ink-canvas/types';
+
+const stroke: InkStroke = {
+	id: 'cached-stroke',
+	points: [[0, 0, 0.5], [20, 10, 0.6], [40, 5, 0.5]],
+	style: { ...DEFAULT_STROKE_STYLE },
+	offset: { x: 0, y: 0 },
+};
+
+describe('rendered stroke cache', () => {
+	test('reuses the rendered outline for the same immutable stroke', () => {
+		const first = getRenderedStrokeData(stroke);
+		const second = getRenderedStrokeData(stroke);
+
+		expect(second).toBe(first);
+		expect(first.pathD).not.toBe('');
+		expect(first.bounds.maxX).toBeGreaterThan(first.bounds.minX);
+	});
+
+	test('keeps translation outside cached path geometry', () => {
+		const movedStroke = { ...stroke, offset: { x: 100, y: 200 } };
+		const original = getRenderedStrokeData(stroke);
+		const moved = getRenderedStrokeData(movedStroke);
+
+		expect(moved.pathD).toBe(original.pathD);
+		expect(moved.bounds).toEqual(original.bounds);
+	});
+});

--- a/tests/ink-canvas/stroke-store.test.ts
+++ b/tests/ink-canvas/stroke-store.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from '@jest/globals';
+import { StrokeStore, type StrokeStoreChange } from 'src/ink-canvas/stroke-store';
+import type { InkStroke } from 'src/ink-canvas/types';
+import { DEFAULT_STROKE_STYLE } from 'src/ink-canvas/types';
+
+function makeStroke(id: string): InkStroke {
+	return {
+		id,
+		points: [[0, 0, 0.5], [10, 10, 0.5]],
+		style: { ...DEFAULT_STROKE_STYLE },
+		offset: { x: 0, y: 0 },
+	};
+}
+
+describe('StrokeStore change notifications', () => {
+	test('identifies only the strokes touched by incremental mutations', () => {
+		const store = new StrokeStore();
+		const changes: StrokeStoreChange[] = [];
+		store.subscribe((change) => changes.push(change));
+
+		store.add(makeStroke('a'));
+		store.addMany([makeStroke('b'), makeStroke('c')]);
+		store.updateOffsets(new Map([['b', { x: 5, y: 8 }]]));
+		store.remove(['a']);
+
+		expect(changes).toEqual([
+			{ type: 'add', ids: ['a'] },
+			{ type: 'addMany', ids: ['b', 'c'] },
+			{ type: 'updateOffsets', ids: ['b'] },
+			{ type: 'remove', ids: ['a'] },
+		]);
+	});
+
+	test('marks whole-store replacement mutations explicitly', () => {
+		const store = new StrokeStore();
+		const changes: StrokeStoreChange[] = [];
+		store.subscribe((change) => changes.push(change));
+
+		store.replaceAll([makeStroke('a')]);
+		store.clear();
+
+		expect(changes).toEqual([
+			{ type: 'replaceAll', ids: [] },
+			{ type: 'clear', ids: [] },
+		]);
+	});
+});

--- a/tests/ink-canvas/svg-export.test.ts
+++ b/tests/ink-canvas/svg-export.test.ts
@@ -42,6 +42,12 @@ describe('svg-export', () => {
 		expect(svg).not.toContain('fill="currentColor"');
 	});
 
+	test('renderStrokesToSvg uses finite fallback bounds for an empty canvas', () => {
+		const svg = renderStrokesToSvg([], emptySnapshot);
+		expect(svg).toContain('viewBox="0 0 1 1"');
+		expect(svg).not.toMatch(/Infinity|NaN/);
+	});
+
 	test('renderStrokesToSvg wraps offset strokes in translate group', () => {
 		const offsetStroke: InkStroke = {
 			...sampleStroke,

--- a/tests/logic/utils/ConvertFileEmbeds.test.ts
+++ b/tests/logic/utils/ConvertFileEmbeds.test.ts
@@ -196,6 +196,11 @@ describe('countFileEmbedOccurrencesInMarkdown', () => {
 		expect(countFileEmbedOccurrencesInMarkdown(markdown, WRITING_PATH, 'inkWriting')).toBe(2);
 	});
 
+	it('counts PDF-safe PNG markers as references to the editable SVG', () => {
+		const markdown = `# Note\n\n${writingLine('Ink/Writing/my-note.png')}\n`;
+		expect(countFileEmbedOccurrencesInMarkdown(markdown, WRITING_PATH, 'inkWriting')).toBe(1);
+	});
+
 	it('returns zero when the file is not embedded', () => {
 		const markdown = `# Note\n\n${writingLine('Ink/Writing/other.svg')}\n`;
 		expect(countFileEmbedOccurrencesInMarkdown(markdown, WRITING_PATH, 'inkWriting')).toBe(0);
@@ -259,6 +264,22 @@ describe('removeAllEmbedsOfFileFromNote', () => {
 		expect(changed).toBe(true);
 		const written = (vault.modify as jest.Mock).mock.calls[0][1] as string;
 		expect(written).not.toContain('![InkDrawing]');
+	});
+
+	it('removes a PDF-safe PNG marker when deleting its editable SVG embed', async () => {
+		const note = { path: 'Notes/PdfSafe.md' } as TFile;
+		const original = `# PDF safe\n\n${writingLine('Ink/Writing/remove-me.png')}\n`;
+		const vault = makeVault({ 'Notes/PdfSafe.md': original });
+
+		const changed = await removeAllEmbedsOfFileFromNote(
+			vault as any,
+			note,
+			WRITING_PATH,
+			'inkWriting',
+		);
+
+		expect(changed).toBe(true);
+		expect((vault.modify as jest.Mock).mock.calls[0][1]).not.toContain('![InkWriting]');
 	});
 
 	it('removes multiple embeds of the same file in one note', async () => {

--- a/tests/logic/utils/detect-reading-mode-ink-embed.test.ts
+++ b/tests/logic/utils/detect-reading-mode-ink-embed.test.ts
@@ -50,6 +50,29 @@ describe('findReadingModeInkEmbedCandidates', () => {
 		expect(candidates[0].embedSettings.embedDisplay.aspectRatio).toBeCloseTo(2.5);
 	});
 
+	it('uses a PDF-safe PNG marker while resolving the editable SVG source', () => {
+		const root = document.createElement('div');
+		root.innerHTML = `
+			<p>
+				<img class="internal-embed" alt="InkWriting" src="Ink/Writing/page.png" />
+				<a href="https://example.com?type=inkWriting&aspectRatio=2.500">Edit Writing</a>
+			</p>
+		`;
+
+		const svgFile = { path: 'Ink/Writing/page.svg' };
+		const getFirstLinkpathDest = jest.fn((path: string) => path.endsWith('.svg') ? svgFile : null);
+		const candidates = findReadingModeInkEmbedCandidates(
+			mockApp(getFirstLinkpathDest),
+			root,
+			'notes/example.md',
+		);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0].partialEmbedFilepath).toBe('Ink/Writing/page.svg');
+		expect(candidates[0].embeddedFile).toBe(svgFile);
+		expect(getFirstLinkpathDest).toHaveBeenCalledWith('Ink/Writing/page.svg', 'notes/example.md');
+	});
+
 	it('finds multiple drawing embeds in the same preview section', () => {
 		const root = document.createElement('div');
 		root.className = 'markdown-preview-section';

--- a/tests/logic/utils/ink-file-has-strokes.test.ts
+++ b/tests/logic/utils/ink-file-has-strokes.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_STROKE_STYLE } from 'src/ink-canvas/types';
 import {
 	getInkStrokesFromSvg,
 	inkFileHasStrokes,
+	sniffInkCanvasHasStrokes,
 	showLockedChrome,
 } from 'src/logic/utils/ink-file-has-strokes';
 
@@ -102,6 +103,23 @@ describe('inkFileHasStrokes', () => {
 			offset: { x: 0, y: 0 },
 		};
 		expect(inkFileHasStrokes(makeInkCanvasSvg([stroke]))).toBe(true);
+	});
+});
+
+describe('sniffInkCanvasHasStrokes', () => {
+	test('detects empty and populated current-format stroke arrays without parsing the SVG', () => {
+		expect(sniffInkCanvasHasStrokes(makeInkCanvasSvg([]))).toBe(false);
+		expect(sniffInkCanvasHasStrokes(makeInkCanvasSvg([{}]))).toBe(true);
+	});
+
+	test('allows whitespace before the first array item', () => {
+		const svg = makeInkCanvasSvg([]).replace('"strokes":[]', '"strokes":[ \n\t]');
+		expect(sniffInkCanvasHasStrokes(svg)).toBe(false);
+	});
+
+	test('falls back for legacy or malformed metadata', () => {
+		expect(sniffInkCanvasHasStrokes(makeTldrawSvg({}))).toBeNull();
+		expect(sniffInkCanvasHasStrokes('<svg><ink-canvas>{"strokes":[')).toBeNull();
 	});
 });
 

--- a/tests/logic/utils/ink-pdf-export.test.ts
+++ b/tests/logic/utils/ink-pdf-export.test.ts
@@ -1,0 +1,28 @@
+import {
+	allowNativeInkPdfPreviewsForNextExport,
+	getInkPdfPreviewPath,
+	getInkSourcePathFromEmbedPath,
+	isInkPdfPreviewPath,
+	shouldUseNativeInkPdfPreviews,
+} from 'src/logic/utils/ink-pdf-export';
+
+describe('Ink PDF export paths', () => {
+	it('maps editable SVGs to same-basename PNG companions', () => {
+		expect(getInkPdfPreviewPath('Ink/Writing/page.svg')).toBe('Ink/Writing/page.png');
+	});
+
+	it('maps PDF preview markers back to editable SVGs', () => {
+		expect(getInkSourcePathFromEmbedPath('Ink/Drawing/sketch.png')).toBe('Ink/Drawing/sketch.svg');
+		expect(getInkSourcePathFromEmbedPath('Ink/Drawing/sketch.svg')).toBe('Ink/Drawing/sketch.svg');
+	});
+
+	it('identifies only PNG companion paths', () => {
+		expect(isInkPdfPreviewPath('Ink/Writing/page.PNG')).toBe(true);
+		expect(isInkPdfPreviewPath('Ink/Writing/page.svg')).toBe(false);
+	});
+
+	it('temporarily lets the PDF exporter use native PNG markers', () => {
+		allowNativeInkPdfPreviewsForNextExport(1000);
+		expect(shouldUseNativeInkPdfPreviews()).toBe(true);
+	});
+});


### PR DESCRIPTION
## Why

I genuinely love Ink and use it every day for handwritten notes across my PC and iPad. Because it is such an important part of my daily workflow, I wanted to improve a performance problem I was consistently reaching in long writing attachments rather than work around it by splitting up my notes.

After writing on one attachment for a long time, pen input became progressively laggy. The same synced note lagged sooner on an 8th-generation iPad than on PC. This is related to #84: v0.5 improved the earlier general lag substantially, but very large ink-canvas attachments could still hitch as they kept growing.

The real-world writing used to reproduce this reached 1,193 strokes, 23,457 input points, and a 3.65 MB SVG. The sample contains personal course notes, so it is not included in the repository.

## Root cause

Several pieces of work scaled with the entire attachment and could land directly on the input thread:

- every autosave regenerated all perfect-freehand outlines twice, once for bounds and again for SVG paths;
- the save pipeline DOM-parsed and pretty-printed the complete multi-megabyte SVG just to replace metadata;
- every stroke invalidated all path and bounds caches and repeatedly rescanned the full document for writing height;
- two equivalent saves were scheduled after each change; and
- an autosave timer could fire after the next Apple Pencil stroke had already started, producing the remaining occasional iPad hitch.

## What changed

- Cache immutable rendered stroke paths and local bounds in a `WeakMap`, shared by the live editor and SVG export without retaining deleted strokes.
- Generate each stroke's path and bounds together during export instead of running perfect-freehand twice.
- Add mutation-aware `StrokeStore` events so only touched cache entries are invalidated; offset-only moves retain their path data.
- Track the writing content bottom incrementally for normal added strokes and avoid redundant full-document height scans.
- Replace only the small `<metadata>` block during ink-canvas saves, preserving rendered SVG markup and using compact, XML-safe JSON instead of DOM parsing and whole-file pretty-printing.
- Remove the redundant second autosave.
- Prevent autosaves from running during active pen/pointer interaction and use a two-second mobile quiet period while retaining the shorter desktop delay.
- Add regression coverage for metadata round trips, cached stroke geometry, store mutation events, and mobile autosave delay selection.

## Measurements

Using the earlier 824-stroke / 16,108-point version of the same real-world writing attachment in a local Node benchmark:

| Save work | Before | After |
| --- | ---: | ---: |
| Stroke rendering | 113.21 ms | 22.03 ms |
| File serialization | 540.89 ms | 13.09 ms |
| Total steady save processing | ~654 ms | ~35 ms |
| Generated SVG size | 3,463,900 bytes | 2,488,112 bytes |

That is approximately a 94.6% reduction in steady save processing and a 28.2% reduction in generated file size in this benchmark. The second pass additionally ensures that the remaining save work never begins in the middle of an active Pencil stroke.

## Validation

- Manually tested with the same synced note on PC and an 8th-generation iPad; writing is now smooth in the previously lagging attachment.
- `npm run test:unit -- --runInBand` — 60 suites and 577 tests passed.
- `npm run build` — TypeScript and production esbuild completed successfully.
- Verified ink-canvas serialization round-trips the complete snapshot without changing stroke data.

Related to #84.
