### PR TITLE
Fix Ink handwriting PDF export

### DIFF
--- a/src/commands/prepare-ink-pdf-export.ts
+++ b/src/commands/prepare-ink-pdf-export.ts
@@ -1,0 +1,118 @@
+import { MarkdownView, Notice, TFile } from 'obsidian';
+import type InkPlugin from 'src/main';
+import {
+	allowNativeInkPdfPreviewsForNextExport,
+	getInkSourcePathFromEmbedPath,
+	writeInkPdfPreview,
+} from 'src/logic/utils/ink-pdf-export';
+
+const INK_IMAGE_MARKER_PATTERN = /!\[(InkWriting|InkDrawing)\]\(<([^>]+)>\)/g;
+
+export type PrepareInkPdfResult = {
+	prepared: number;
+	missing: number;
+};
+
+export async function prepareNoteInkForPdfExport(
+	plugin: InkPlugin,
+	note: TFile,
+): Promise<PrepareInkPdfResult> {
+	const markdown = await plugin.app.vault.read(note);
+	const sourcePaths = new Set<string>();
+
+	for (const match of markdown.matchAll(INK_IMAGE_MARKER_PATTERN)) {
+		sourcePaths.add(getInkSourcePathFromEmbedPath(match[2]));
+	}
+
+	let prepared = 0;
+	let missing = 0;
+	const previewBySourcePath = new Map<string, string>();
+
+	for (const sourcePath of sourcePaths) {
+		const sourceFile = plugin.app.metadataCache.getFirstLinkpathDest(sourcePath, note.path);
+		if (!(sourceFile instanceof TFile) || sourceFile.extension.toLowerCase() !== 'svg') {
+			missing += 1;
+			continue;
+		}
+
+		const previewPath = await writeInkPdfPreview(plugin, sourceFile);
+		previewBySourcePath.set(sourcePath, previewPath);
+		prepared += 1;
+	}
+
+	const updatedMarkdown = markdown.replace(
+		INK_IMAGE_MARKER_PATTERN,
+		(fullMarker, altText: string, markerPath: string) => {
+			const sourcePath = getInkSourcePathFromEmbedPath(markerPath);
+			const previewPath = previewBySourcePath.get(sourcePath);
+			if (!previewPath) return fullMarker;
+			return `![${altText}](<${previewPath}>)`;
+		},
+	);
+
+	if (updatedMarkdown !== markdown) {
+		await plugin.app.vault.modify(note, updatedMarkdown);
+	}
+
+	return { prepared, missing };
+}
+
+export function registerPrepareInkPdfExportCommand(plugin: InkPlugin): void {
+	plugin.addCommand({
+		id: 'prepare-current-note-ink-for-pdf-export',
+		name: 'Prepare current note handwriting for PDF export',
+		checkCallback: (checking) => {
+			const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+			if (!view?.file) return false;
+			if (checking) return true;
+
+			void (async () => {
+				new Notice('Preparing Ink handwriting for PDF export…');
+				try {
+					const result = await prepareNoteInkForPdfExport(plugin, view.file as TFile);
+					const missingSuffix = result.missing > 0
+						? ` (${result.missing} missing attachment${result.missing === 1 ? '' : 's'} skipped)`
+						: '';
+					new Notice(`Ink PDF previews ready: ${result.prepared}${missingSuffix}`);
+				} catch (error) {
+					console.error('Unable to prepare Ink handwriting for PDF export', error);
+					new Notice('Could not prepare Ink handwriting for PDF export. See console for details.');
+				}
+			})();
+			return true;
+		},
+	});
+
+	plugin.addCommand({
+		id: 'export-current-note-to-pdf-with-ink',
+		name: 'Export current note to PDF with Ink',
+		checkCallback: (checking) => {
+			const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+			if (!view?.file) return false;
+			if (checking) return true;
+
+			void (async () => {
+				new Notice('Preparing Ink handwriting for PDF export…');
+				try {
+					const result = await prepareNoteInkForPdfExport(plugin, view.file as TFile);
+					allowNativeInkPdfPreviewsForNextExport();
+					const appWithCommands = plugin.app as typeof plugin.app & {
+						commands?: { executeCommandById: (id: string) => boolean };
+					};
+					const opened = appWithCommands.commands?.executeCommandById('workspace:export-pdf') ?? false;
+					if (!opened) {
+						new Notice('Ink previews are ready. Run Obsidian’s “Export to PDF” command now.');
+						return;
+					}
+					if (result.missing > 0) {
+						new Notice(`${result.missing} missing Ink attachment${result.missing === 1 ? '' : 's'} skipped.`);
+					}
+				} catch (error) {
+					console.error('Unable to export PDF with Ink handwriting', error);
+					new Notice('Could not prepare Ink handwriting for PDF export. See console for details.');
+				}
+			})();
+			return true;
+		},
+	});
+}

--- a/src/components/formats/current/drawing/drawing-embed-extension/drawing-embed-extension.tsx
+++ b/src/components/formats/current/drawing/drawing-embed-extension/drawing-embed-extension.tsx
@@ -29,6 +29,10 @@ import { preventWidgetRootStealingFocus } from '../../utils/preventWidgetRootSte
 import { preventCodeMirrorHandlingWidgetsEvents } from '../../utils/createWidgetRootDomEventHandlers';
 import { parseSettingsFromUrl } from '../../utils/parse-settings-from-url';
 import { buildFileStr } from '../../utils/buildFileStr';
+import {
+	getInkSourcePathFromEmbedPath,
+	scheduleInkPdfPreviewRefresh,
+} from 'src/logic/utils/ink-pdf-export';
 import { buildDrawingEmbedLine, buildWritingEmbedLine } from '../../utils/build-embeds';
 import { buildDrawingEmbedSettingsFromFile } from 'src/logic/utils/build-drawing-embed-settings-from-file';
 import { duplicateDrawingFile } from '../../utils/duplicate-files';
@@ -191,6 +195,7 @@ export class DrawingEmbedWidget extends WidgetType {
 		const plugin = getGlobals().plugin;
 		const inkFileContents = buildFileStr(inkFileData);
 		await plugin.app.vault.modify(this.embeddedFile, inkFileContents);
+		scheduleInkPdfPreviewRefresh(plugin, this.embeddedFile, inkFileData.svgString);
 	}
 
 	setEmbedProps = async (view: EditorView, width: number, aspectRatio: number) => {
@@ -843,6 +848,7 @@ function detectMarkdownEmbedLink(mdFile: TFile, previewLinkStartNode: SyntaxNode
     
     // It's definitely a markdown embed, let's now focus on the urlText to check it's an Ink embed.
     const previewPartialFilepath = transaction.state.doc.sliceString(previewFilepathNode.from+1, previewFilepathNode.to-1); // +&- to remove <> brackets
+	const inkSourceFilepath = getInkSourcePathFromEmbedPath(previewPartialFilepath);
     const urlAndSettings = transaction.state.doc.sliceString(settingsUrlPathNode.from, settingsUrlPathNode.to);
     // Require query param to include type=InkDrawing (host agnostic)
     if (!urlAndSettings.includes('type=inkDrawing')) {
@@ -867,7 +873,7 @@ function detectMarkdownEmbedLink(mdFile: TFile, previewLinkStartNode: SyntaxNode
     //     embedSettings.transcription = transaction.state.doc.sliceString(altTextNode.from, altTextNode.to);
     // }
 
-    const embeddedFile = plugin.app.metadataCache.getFirstLinkpathDest(normalizePath(previewPartialFilepath), mdFile.path)
+    const embeddedFile = plugin.app.metadataCache.getFirstLinkpathDest(normalizePath(inkSourceFilepath), mdFile.path)
 
     return {
         embedLinkInfo: {
@@ -875,7 +881,7 @@ function detectMarkdownEmbedLink(mdFile: TFile, previewLinkStartNode: SyntaxNode
             endPosition: endOfReplacement,
             embeddedFile: embeddedFile,
             embedSettings: embedSettings,
-            partialEmbedFilepath: previewPartialFilepath,
+            partialEmbedFilepath: inkSourceFilepath,
             isPendingPaste: isPendingPaste,
         },
     }

--- a/src/components/formats/current/drawing/drawing-view/drawing-view.tsx
+++ b/src/components/formats/current/drawing/drawing-view/drawing-view.tsx
@@ -7,6 +7,7 @@ import {
 	Provider as JotaiProvider
 } from "jotai";
 import { buildFileStr } from "../../utils/buildFileStr";
+import { scheduleInkPdfPreviewRefresh } from 'src/logic/utils/ink-pdf-export';
 import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
 import { ensureThemedNativeInkSvgView } from "src/logic/utils/addEditButtonToSvgView";
 import { openInkFileInView, restoreSidebarsAfterInkView } from "src/logic/utils/open-file";
@@ -184,6 +185,7 @@ export class DrawingView extends TextFileView {
 
     saveFile = (inkFileData: InkFileData) => {
         this.inkFileData = inkFileData;
+		if (this.file) scheduleInkPdfPreviewRefresh(this.plugin, this.file, inkFileData.svgString);
         void this.save(false);   // Obsidian will call getViewData during this method
     }
     

--- a/src/components/formats/current/reading-mode/register-reading-mode-ink-embeds.ts
+++ b/src/components/formats/current/reading-mode/register-reading-mode-ink-embeds.ts
@@ -11,6 +11,7 @@ import { InkEmbedKind } from 'src/logic/utils/embed';
 import { EmbedSettings } from 'src/types/embed-settings';
 import { InkReadingEmbedHost, refreshReadingModeEmbedDimensionsInRoot } from './ink-reading-embed-host';
 import { refreshLivePreviewEmbedsWhenReady } from '../ink-embeds-extension/ink-embed-refresh';
+import { shouldUseNativeInkPdfPreviews } from 'src/logic/utils/ink-pdf-export';
 import '../drawing/drawing-embed/drawing-embed.scss';
 import '../drawing/drawing-embed-preview/drawing-embed-preview.scss';
 import '../writing/writing-embed/writing-embed.scss';
@@ -30,6 +31,10 @@ export function registerReadingModeInkEmbeds(plugin: InkPlugin) {
 	// Reading mode passes section elements (p, .el-p, …); PDF export passes the entire
 	// .markdown-preview-view — both roots must be accepted or export shows the full SVG.
 	plugin.registerMarkdownPostProcessor((element, context) => {
+		// The PDF-safe command deliberately leaves PNG companion markers native.
+		// Obsidian's exporter includes PNGs but drops the themed inline SVG host.
+		if (shouldUseNativeInkPdfPreviews()) return;
+
 		const matchesScanRoot = element.matches(READING_MODE_EMBED_SCAN_ROOT_SELECTOR);
 		const isFullPagePreviewRoot = element.matches(FULL_PAGE_PREVIEW_ROOT_SELECTOR);
 		if (!matchesScanRoot && !isFullPagePreviewRoot) return;

--- a/src/components/formats/current/writing/writing-embed-extension/writing-embed-extension.tsx
+++ b/src/components/formats/current/writing/writing-embed-extension/writing-embed-extension.tsx
@@ -30,6 +30,10 @@ import {
 	patchWritingEmbedAspectRatioInEmbedSnippet,
 	readWritingFileAspectRatio,
 } from 'src/logic/utils/writing-embed-aspect-ratio';
+import {
+	getInkSourcePathFromEmbedPath,
+	scheduleInkPdfPreviewRefresh,
+} from 'src/logic/utils/ink-pdf-export';
 
 
 // Parity with drawing v2, but simplified (no width/aspect updates for writing embeds)
@@ -189,6 +193,7 @@ export class WritingEmbedWidget extends WidgetType {
         const plugin = getGlobals().plugin;
         const pageDataStr = buildFileStr(pageData);
         await plugin.app.vault.modify(this.embeddedFile, pageDataStr);
+		scheduleInkPdfPreviewRefresh(plugin, this.embeddedFile, pageData.svgString);
     };
 
     private onRequestMeasure(view: EditorView) {
@@ -667,13 +672,14 @@ function detectMarkdownEmbedLinkWriting(
     }
 
     const previewPartialFilepath = transaction.state.doc.sliceString(previewFilepathNode.from + 1, previewFilepathNode.to - 1);
+	const inkSourceFilepath = getInkSourcePathFromEmbedPath(previewPartialFilepath);
     const startOfReplacement = previewLinkStartNode.from;
     const endOfReplacement = settingsUrlEndNode.to;
 
     // Parse settings from URL parameters
     const { embedSettings, isPendingPaste } = parseSettingsFromUrl(urlAndSettings);
 
-    const embeddedFile = plugin.app.metadataCache.getFirstLinkpathDest(normalizePath(previewPartialFilepath), mdFile.path);
+    const embeddedFile = plugin.app.metadataCache.getFirstLinkpathDest(normalizePath(inkSourceFilepath), mdFile.path);
 
     return {
         embedLinkInfo: {
@@ -681,7 +687,7 @@ function detectMarkdownEmbedLinkWriting(
             endPosition: endOfReplacement,
             embeddedFile: embeddedFile,
             embedSettings: embedSettings,
-            partialEmbedFilepath: previewPartialFilepath,
+            partialEmbedFilepath: inkSourceFilepath,
             isPendingPaste: isPendingPaste,
         },
     };

--- a/src/components/formats/current/writing/writing-view/writing-view.tsx
+++ b/src/components/formats/current/writing/writing-view/writing-view.tsx
@@ -7,6 +7,7 @@ import { InkFileData } from "src/components/formats/current/types/file-data";
 import { WritingEditor } from "../writing-editor/writing-editor";
 import { type MenuOption } from "src/components/jsx-components/overflow-menu/overflow-menu";
 import { buildFileStr } from "../../utils/buildFileStr";
+import { scheduleInkPdfPreviewRefresh } from 'src/logic/utils/ink-pdf-export';
 import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
 import { WritingEditorControls } from "../writing-embed/writing-embed";
 import { ensureThemedNativeInkSvgView } from "src/logic/utils/addEditButtonToSvgView";
@@ -175,6 +176,7 @@ export class WritingView extends TextFileView {
 
     saveFile = (inkFileData: InkFileData) => {
         this.inkFileData = inkFileData;
+		if (this.file) scheduleInkPdfPreviewRefresh(this.plugin, this.file, inkFileData.svgString);
         void this.save(false);   // Obsidian will call getViewData during this method
     }
 

--- a/src/logic/utils/convert-file-embeds.ts
+++ b/src/logic/utils/convert-file-embeds.ts
@@ -9,6 +9,7 @@ import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
 import { buildDrawingEmbedSettingsFromStrokes } from "src/logic/utils/build-drawing-embed-settings-from-file";
 import { parseSvgViewBoxAspectRatio } from "src/logic/utils/writing-embed-aspect-ratio";
 import type { EmbedSettings } from "src/types/embed-settings";
+import { getInkPdfPreviewPath } from 'src/logic/utils/ink-pdf-export';
 // View type strings (avoid importing from view modules to prevent heavy deps in tests)
 const INK_WRITING_VIEW_TYPE = "ink_writing-view";
 const INK_DRAWING_VIEW_TYPE = "ink_drawing-view";
@@ -65,9 +66,10 @@ function buildFileEmbedPattern(
 	global = false,
 ): RegExp {
 	const escapedPath = svgFilePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const escapedPreviewPath = getInkPdfPreviewPath(svgFilePath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	const altText = embedType === 'inkWriting' ? 'InkWriting' : 'InkDrawing';
 	return new RegExp(
-		` !\\[${altText}\\]\\(<${escapedPath}>\\)`,
+		` !\\[${altText}\\]\\(<(?:${escapedPath}|${escapedPreviewPath})>\\)`,
 		global ? 'g' : undefined,
 	);
 }
@@ -159,10 +161,11 @@ export async function removeAllEmbedsOfFileFromNote(
 	let content = await vault.read(note);
 
 	const escapedPath = svgFilePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const escapedPreviewPath = getInkPdfPreviewPath(svgFilePath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	const altText = embedType === 'inkWriting' ? 'InkWriting' : 'InkDrawing';
 	// Match the full embed line (everything up to and including the newline)
 	const lineRegex = new RegExp(
-		` !\\[${altText}\\]\\(<${escapedPath}>\\)[^\\n]*\\r?\\n?`,
+		` !\\[${altText}\\]\\(<(?:${escapedPath}|${escapedPreviewPath})>\\)[^\\n]*\\r?\\n?`,
 		'g',
 	);
 
@@ -232,10 +235,11 @@ export async function updateEmbedInNote(
 	let content = await vault.read(note);
 
 	const escapedOldPath = oldSvgPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const escapedOldPreviewPath = getInkPdfPreviewPath(oldSvgPath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	const fromAlt = toType === 'inkWriting' ? 'InkDrawing' : 'InkWriting';
 	// Match the full embed line (everything up to end of line)
 	const lineRegex = new RegExp(
-		` !\\[${fromAlt}\\]\\(<${escapedOldPath}>\\)[^\n]*`,
+		` !\\[${fromAlt}\\]\\(<(?:${escapedOldPath}|${escapedOldPreviewPath})>\\)[^\n]*`,
 		'g',
 	);
 

--- a/src/logic/utils/detect-reading-mode-ink-embed.ts
+++ b/src/logic/utils/detect-reading-mode-ink-embed.ts
@@ -2,6 +2,7 @@ import { App, normalizePath, TFile } from 'obsidian';
 import { parseSettingsFromUrl } from 'src/components/formats/current/utils/parse-settings-from-url';
 import { EmbedSettings } from 'src/types/embed-settings';
 import { InkEmbedKind } from './embed';
+import { getInkSourcePathFromEmbedPath } from './ink-pdf-export';
 
 export const INK_READING_PROCESSED_ATTR = 'data-ink-reading-processed';
 /** Set while a MarkdownRenderChild is mounted into the host. */
@@ -49,8 +50,9 @@ export function findReadingModeInkEmbedCandidates(
 			const editLinkEl = findInkEditLinkForMarker(embedMarkerEl, editLinkFragment);
 			if (!editLinkEl) return;
 
-			const partialEmbedFilepath = extractPartialEmbedFilepath(embedMarkerEl);
-			if (!partialEmbedFilepath) return;
+			const markerFilepath = extractPartialEmbedFilepath(embedMarkerEl);
+			if (!markerFilepath) return;
+			const partialEmbedFilepath = getInkSourcePathFromEmbedPath(markerFilepath);
 
 			const settingsHref = editLinkEl.getAttribute('href') ?? '';
 			const { embedSettings, isPendingPaste } = parseSettingsFromUrl(settingsHref);

--- a/src/logic/utils/ink-pdf-export.ts
+++ b/src/logic/utils/ink-pdf-export.ts
@@ -1,0 +1,99 @@
+import { normalizePath, TFile } from 'obsidian';
+import type InkPlugin from 'src/main';
+import { getPreviewFileVaultPath } from './getPreviewFileVaultPath';
+import { savePngExport } from './savePngExport';
+import { svgToPngDataUri } from './screenshots';
+
+const PDF_PREVIEW_REFRESH_DELAY_MS = 1200;
+let nativePdfPreviewUntil = 0;
+
+type PendingPreviewRefresh = {
+	timer: number;
+	plugin: InkPlugin;
+	file: TFile;
+	svgString: string;
+};
+
+const pendingPreviewRefreshes = new Map<string, PendingPreviewRefresh>();
+
+export function allowNativeInkPdfPreviewsForNextExport(timeoutMs = 120000): void {
+	nativePdfPreviewUntil = Date.now() + timeoutMs;
+}
+
+export function shouldUseNativeInkPdfPreviews(): boolean {
+	return Date.now() < nativePdfPreviewUntil;
+}
+
+export function getInkPdfPreviewPath(svgPath: string): string {
+	return normalizePath(svgPath.replace(/\.svg$/i, '.png'));
+}
+
+/** PNG markers use the same basename as their editable SVG attachment. */
+export function getInkSourcePathFromEmbedPath(embedPath: string): string {
+	return normalizePath(embedPath.replace(/\.png$/i, '.svg'));
+}
+
+export function isInkPdfPreviewPath(path: string): boolean {
+	return /\.png$/i.test(path);
+}
+
+/**
+ * Rasterize an Ink SVG once for Obsidian's PDF exporter, which omits local SVG
+ * attachments. The SVG remains the editable source; this PNG is only a preview.
+ */
+export async function writeInkPdfPreview(
+	plugin: InkPlugin,
+	file: TFile,
+	svgString?: string,
+): Promise<string> {
+	const svg = svgString ?? await plugin.app.vault.cachedRead(file);
+	const dimensions = readSvgDimensions(svg);
+	if (!dimensions) throw new Error(`Ink SVG has no valid viewBox: ${file.path}`);
+
+	const dataUri = await svgToPngDataUri({ ...dimensions, svg });
+	if (!dataUri) throw new Error(`Could not render PDF preview: ${file.path}`);
+
+	await savePngExport(plugin, dataUri, file);
+	return getInkPdfPreviewPath(file.path);
+}
+
+/**
+ * Coalesce autosaves and do no work for legacy SVG-only embeds. Once a PNG
+ * companion exists, its refresh runs after the pen has been idle for a moment.
+ */
+export function scheduleInkPdfPreviewRefresh(
+	plugin: InkPlugin,
+	file: TFile,
+	svgString: string,
+): void {
+	const previewPath = getInkPdfPreviewPath(file.path);
+	const previewFile = plugin.app.vault.getAbstractFileByPath(previewPath);
+	if (!(previewFile instanceof TFile)) return;
+
+	const previous = pendingPreviewRefreshes.get(file.path);
+	if (previous) window.clearTimeout(previous.timer);
+
+	const pending: PendingPreviewRefresh = {
+		plugin,
+		file,
+		svgString,
+		timer: window.setTimeout(() => {
+			pendingPreviewRefreshes.delete(file.path);
+			void writeInkPdfPreview(plugin, file, svgString).catch((error) => {
+				console.error('Unable to refresh Ink PDF preview', error);
+			});
+		}, PDF_PREVIEW_REFRESH_DELAY_MS),
+	};
+	pendingPreviewRefreshes.set(file.path, pending);
+}
+
+function readSvgDimensions(svg: string): { width: number; height: number } | null {
+	const match = svg.match(/<svg\b[^>]*\bviewBox\s*=\s*["']([^"']+)["']/i);
+	if (!match) return null;
+	const parts = match[1].trim().split(/[\s,]+/).map(Number);
+	if (parts.length < 4) return null;
+	const width = parts[2];
+	const height = parts[3];
+	if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
+	return { width, height };
+}

--- a/src/logic/utils/screenshots.ts
+++ b/src/logic/utils/screenshots.ts
@@ -3,24 +3,18 @@ import { Canvg } from 'canvg';
 //////////
 //////////
 
-export async function svgToPngDataUri(svgObj: {	height: number,	width: number, svg: string, }): Promise<string | null> {
+export async function svgToPngDataUri(svgObj: { height: number; width: number; svg: string }): Promise<string | null> {
 	try {
-		// Extract width and height from the SVG element
-		let width = svgObj.width;
-		let height = svgObj.height;
-		
-        // Scale up or down
-		if (width > 1500 || height > 2000) {
-			while(width > 1500) {
-				width /= 2;
-				height /= 2;
-			}
-		} else if(width < 500) {
-			while(width < 500) {
-				width *= 2;
-				height *= 2;
-			}
-		} 
+		const sourceWidth = Math.max(1, svgObj.width);
+		const sourceHeight = Math.max(1, svgObj.height);
+		// Two device pixels per typical 700px note column keeps handwriting crisp in
+		// PDF without retaining the often much larger SVG coordinate dimensions.
+		const widthScale = Math.min(1, 1400 / sourceWidth);
+		const heightScale = Math.min(1, 16000 / sourceHeight);
+		const upscale = sourceWidth < 600 ? 600 / sourceWidth : 1;
+		const scale = Math.min(upscale, widthScale, heightScale);
+		const width = Math.max(1, Math.round(sourceWidth * scale));
+		const height = Math.max(1, Math.round(sourceHeight * scale));
 		
 		// Set canvas dimensions
 		const canvas = activeDocument.createElement('canvas');
@@ -35,15 +29,13 @@ export async function svgToPngDataUri(svgObj: {	height: number,	width: number, s
 		// Render SVG onto canvas
 		const svgStr = svgObj.svg;
 		const canvgRenderer = await Canvg.from(ctx, svgStr);
-        canvgRenderer.resize(width, height, 'xMidYMid meet')
-		canvgRenderer.start();
+		canvgRenderer.resize(width, height, 'xMidYMid meet');
+		await canvgRenderer.render();
 		
 		// Convert canvas to PNG data URI with transparent background
-		// @ts-ignore
-		const dataURL = canvas.toDataURL('image/png', {alpha: true});
+		const dataURL = canvas.toDataURL('image/png');
 		
 		// Remove temporary canvas element
-		canvgRenderer.stop();
 		canvas.remove();
 
 		return dataURL;

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ import {
 	resetFingerDrawingToDefault,
 	setBooxConnectionEnabled,
 } from 'src/logic/device-settings/device-settings';
+import { registerPrepareInkPdfExportCommand } from 'src/commands/prepare-ink-pdf-export';
 
 ////////
 ////////
@@ -166,6 +167,7 @@ export default class InkPlugin extends Plugin {
 			this.registerEditorExtension([inkEmbedsExtension()]);
 			registerPasteEmbedHandler(this);
 			registerReadingModeInkEmbeds(this);
+			registerPrepareInkPdfExportCommand(this);
 		}
 
 		registerSettingsTab(this);

--- a/tests/logic/utils/ConvertFileEmbeds.test.ts
+++ b/tests/logic/utils/ConvertFileEmbeds.test.ts
@@ -196,6 +196,11 @@ describe('countFileEmbedOccurrencesInMarkdown', () => {
 		expect(countFileEmbedOccurrencesInMarkdown(markdown, WRITING_PATH, 'inkWriting')).toBe(2);
 	});
 
+	it('counts PDF-safe PNG markers as references to the editable SVG', () => {
+		const markdown = `# Note\n\n${writingLine('Ink/Writing/my-note.png')}\n`;
+		expect(countFileEmbedOccurrencesInMarkdown(markdown, WRITING_PATH, 'inkWriting')).toBe(1);
+	});
+
 	it('returns zero when the file is not embedded', () => {
 		const markdown = `# Note\n\n${writingLine('Ink/Writing/other.svg')}\n`;
 		expect(countFileEmbedOccurrencesInMarkdown(markdown, WRITING_PATH, 'inkWriting')).toBe(0);
@@ -259,6 +264,22 @@ describe('removeAllEmbedsOfFileFromNote', () => {
 		expect(changed).toBe(true);
 		const written = (vault.modify as jest.Mock).mock.calls[0][1] as string;
 		expect(written).not.toContain('![InkDrawing]');
+	});
+
+	it('removes a PDF-safe PNG marker when deleting its editable SVG embed', async () => {
+		const note = { path: 'Notes/PdfSafe.md' } as TFile;
+		const original = `# PDF safe\n\n${writingLine('Ink/Writing/remove-me.png')}\n`;
+		const vault = makeVault({ 'Notes/PdfSafe.md': original });
+
+		const changed = await removeAllEmbedsOfFileFromNote(
+			vault as any,
+			note,
+			WRITING_PATH,
+			'inkWriting',
+		);
+
+		expect(changed).toBe(true);
+		expect((vault.modify as jest.Mock).mock.calls[0][1]).not.toContain('![InkWriting]');
 	});
 
 	it('removes multiple embeds of the same file in one note', async () => {

--- a/tests/logic/utils/detect-reading-mode-ink-embed.test.ts
+++ b/tests/logic/utils/detect-reading-mode-ink-embed.test.ts
@@ -50,6 +50,29 @@ describe('findReadingModeInkEmbedCandidates', () => {
 		expect(candidates[0].embedSettings.embedDisplay.aspectRatio).toBeCloseTo(2.5);
 	});
 
+	it('uses a PDF-safe PNG marker while resolving the editable SVG source', () => {
+		const root = document.createElement('div');
+		root.innerHTML = `
+			<p>
+				<img class="internal-embed" alt="InkWriting" src="Ink/Writing/page.png" />
+				<a href="https://example.com?type=inkWriting&aspectRatio=2.500">Edit Writing</a>
+			</p>
+		`;
+
+		const svgFile = { path: 'Ink/Writing/page.svg' };
+		const getFirstLinkpathDest = jest.fn((path: string) => path.endsWith('.svg') ? svgFile : null);
+		const candidates = findReadingModeInkEmbedCandidates(
+			mockApp(getFirstLinkpathDest),
+			root,
+			'notes/example.md',
+		);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0].partialEmbedFilepath).toBe('Ink/Writing/page.svg');
+		expect(candidates[0].embeddedFile).toBe(svgFile);
+		expect(getFirstLinkpathDest).toHaveBeenCalledWith('Ink/Writing/page.svg', 'notes/example.md');
+	});
+
 	it('finds multiple drawing embeds in the same preview section', () => {
 		const root = document.createElement('div');
 		root.className = 'markdown-preview-section';

--- a/tests/logic/utils/ink-pdf-export.test.ts
+++ b/tests/logic/utils/ink-pdf-export.test.ts
@@ -1,0 +1,28 @@
+import {
+	allowNativeInkPdfPreviewsForNextExport,
+	getInkPdfPreviewPath,
+	getInkSourcePathFromEmbedPath,
+	isInkPdfPreviewPath,
+	shouldUseNativeInkPdfPreviews,
+} from 'src/logic/utils/ink-pdf-export';
+
+describe('Ink PDF export paths', () => {
+	it('maps editable SVGs to same-basename PNG companions', () => {
+		expect(getInkPdfPreviewPath('Ink/Writing/page.svg')).toBe('Ink/Writing/page.png');
+	});
+
+	it('maps PDF preview markers back to editable SVGs', () => {
+		expect(getInkSourcePathFromEmbedPath('Ink/Drawing/sketch.png')).toBe('Ink/Drawing/sketch.svg');
+		expect(getInkSourcePathFromEmbedPath('Ink/Drawing/sketch.svg')).toBe('Ink/Drawing/sketch.svg');
+	});
+
+	it('identifies only PNG companion paths', () => {
+		expect(isInkPdfPreviewPath('Ink/Writing/page.PNG')).toBe(true);
+		expect(isInkPdfPreviewPath('Ink/Writing/page.svg')).toBe(false);
+	});
+
+	it('temporarily lets the PDF exporter use native PNG markers', () => {
+		allowNativeInkPdfPreviewsForNextExport(1000);
+		expect(shouldUseNativeInkPdfPreviews()).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Extracted from [#198](https://github.com/daledesilva/obsidian_ink/pull/198) so PDF export can be reviewed separately from the large-canvas performance work.
- Adds commands to prepare Ink handwriting for Obsidian’s PDF exporter via PNG companion previews, plus embed/path helpers so PNG markers still resolve to the editable SVG source.
- **Original author:** [@Llewellyn500](https://github.com/Llewellyn500) (Llewellyn Adonteng Paintsil). Commit authorship is preserved from their PR.

## Notes
This change rewrites note embed markers to `.png` during prepare/export and refreshes companion PNGs after saves when a preview already exists. Product fit should be reviewed independently of the performance PR.

## Test plan
- [ ] Run **Prepare current note handwriting for PDF export** on a note with Ink writing/drawing embeds
- [ ] Confirm companion `.png` files are written beside the SVG attachments
- [ ] Run **Export current note to PDF with Ink** (or prepare + native Export to PDF) and confirm handwriting appears in the PDF
- [ ] Confirm Edit Writing / Edit Drawing still opens the SVG source after markers point at PNG
- [ ] `npm run test:unit -- --runInBand` for the added PDF/embed path tests


Made with [Cursor](https://cursor.com)