### PR TITLE
Improve large Ink canvas performance

### DIFF
--- a/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.scss
+++ b/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.scss
@@ -1,5 +1,3 @@
-@use '../../../shared/ink-svg-preview-theme';
-
 /////////
 /////////
 

--- a/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
+++ b/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
@@ -1,13 +1,13 @@
 import './drawing-editor.scss';
 import * as React from 'react';
 import { useRef } from 'react';
-import { TFile } from 'obsidian';
+import { Platform, TFile } from 'obsidian';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
 import { InkFileData } from 'src/components/formats/current/types/file-data';
 import { buildInkCanvasDrawingFileData } from 'src/components/formats/current/utils/build-file-data';
 import { isInkCanvasFile } from 'src/components/formats/current/utils/ink-file-storage-engine';
-import { DRAW_SHORT_DELAY_MS, DRAW_LONG_DELAY_MS } from 'src/constants';
+import { DRAW_LONG_DELAY_MS, DRAW_SHORT_DELAY_MS } from 'src/constants';
 import { PrimaryMenuBar } from 'src/components/jsx-components/primary-menu-bar/primary-menu-bar';
 import { InkCanvasDrawingMenu } from 'src/components/jsx-components/drawing-menu/ink-canvas-drawing-menu';
 import ExtendedDrawingMenu from 'src/components/jsx-components/extended-drawing-menu/extended-drawing-menu';
@@ -32,6 +32,7 @@ import {
 } from 'src/logic/undo-redo/embedded-unified-undo';
 import { InkSvgCanvas } from 'src/ink-canvas/ink-svg-canvas';
 import { renderStrokesToSvg } from 'src/ink-canvas/svg-export';
+import { resolveInkAutosaveDelayMs } from 'src/ink-canvas/autosave-delay';
 import { migrateFromTldraw } from 'src/ink-canvas/migrate-from-tldraw';
 import { useDominantHand } from 'src/stores/dominant-hand-store';
 import { Notice } from 'obsidian';
@@ -102,7 +103,8 @@ export function DrawingEditor(props: DrawingEditorProps) {
 	const [isFingerDrawingActive, setIsFingerDrawingActive] = React.useState(false);
 	const [initialSnapshot, setInitialSnapshot] = React.useState<InkCanvasSnapshot>();
 	const shortDelayTimerRef = useRef<number>();
-	const longDelayTimerRef = useRef<number>();
+	const canvasInteractionActiveRef = useRef(false);
+	const hasUnsavedChangesRef = useRef(false);
 	const editorRef = useRef<InkCanvasEditor>();
 	const editorWrapperRefEl = useRef<HTMLDivElement>(null);
 	const websocketConnectedRef = useRef(false);
@@ -351,7 +353,17 @@ export function DrawingEditor(props: DrawingEditorProps) {
 	}
 
 	function handleStoreChange() {
+		hasUnsavedChangesRef.current = true;
 		queueSaves();
+	}
+
+	function handleCanvasInteractionChange(active: boolean) {
+		canvasInteractionActiveRef.current = active;
+		if (active) {
+			resetTimers();
+			return;
+		}
+		if (hasUnsavedChangesRef.current) queueSaves();
 	}
 
 	function handleEmbedUndoStackPush() {
@@ -366,15 +378,18 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 	function queueSaves() {
 		resetTimers();
+		if (canvasInteractionActiveRef.current) return;
+		const delayMs = resolveInkAutosaveDelayMs(Platform, DRAW_SHORT_DELAY_MS, DRAW_LONG_DELAY_MS);
 		shortDelayTimerRef.current = window.setTimeout(() => {
 			void incrementalSave();
-		}, DRAW_SHORT_DELAY_MS);
-		longDelayTimerRef.current = window.setTimeout(() => {
-			void completeSave();
-		}, DRAW_LONG_DELAY_MS);
+		}, delayMs);
 	}
 
 	async function incrementalSave() {
+		if (canvasInteractionActiveRef.current) {
+			queueSaves();
+			return;
+		}
 		const editor = editorRef.current;
 		if (!editor) return;
 		verbose('incrementalSave (ink-canvas)');
@@ -382,6 +397,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 		const snapshot = editor.getSnapshot();
 		const svgString = renderStrokesToSvg(snapshot.strokes, snapshot);
+		hasUnsavedChangesRef.current = false;
 		const fileData = buildInkCanvasDrawingFileData({
 			inkCanvasSnapshot: snapshot,
 			svgString,
@@ -397,6 +413,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 		const snapshot = editor.getSnapshot();
 		const svgString = renderStrokesToSvg(snapshot.strokes, snapshot);
+		hasUnsavedChangesRef.current = false;
 		const fileData = buildInkCanvasDrawingFileData({
 			inkCanvasSnapshot: snapshot,
 			svgString,
@@ -406,7 +423,6 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 	function resetTimers() {
 		window.clearTimeout(shortDelayTimerRef.current);
-		window.clearTimeout(longDelayTimerRef.current);
 	}
 
 
@@ -754,6 +770,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 				initialSnapshot={initialSnapshot}
 				onEditorReady={handleEditorReady}
 				onChange={handleStoreChange}
+				onInteractionChange={handleCanvasInteractionChange}
 				onEmbedUndoStackPush={handleEmbedUndoStackPush}
 				onCameraChange={(camera, containerRect, meta) => {
 					if (meta.source === 'user') hasUserMovedCameraRef.current = true;

--- a/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.scss
+++ b/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.scss
@@ -1,5 +1,3 @@
-@use '../../../../shared/ink-svg-preview-theme';
-
 .ddc_ink_drawing-embed-preview {
     pointer-events: none;
 

--- a/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.tsx
+++ b/src/components/formats/current/drawing/drawing-embed-preview/drawing-embed-preview.tsx
@@ -93,7 +93,7 @@ export const DrawingEmbedPreview: React.FC<DrawingEmbedPreviewProps> = (props) =
                         cursor: 'pointer'
                     }}
                     pointerEvents = "visible"
-                    cacheRequests = {false}
+                    cacheRequests = {true}
                     key = {fileSrc}
                     onLoad = {onLoad}
                     viewBox = {props.embedSettings?.viewBox

--- a/src/components/formats/current/drawing/drawing-embed/drawing-embed.scss
+++ b/src/components/formats/current/drawing/drawing-embed/drawing-embed.scss
@@ -1,4 +1,3 @@
-@use '../../../../shared/ink-svg-preview-theme';
 @use '../../../../../styles/ink-boox-eink-chrome';
 
 // Boox: disable transition on the editor canvas only (stroke latency).

--- a/src/components/formats/current/reading-mode/ink-reading-embed-host.tsx
+++ b/src/components/formats/current/reading-mode/ink-reading-embed-host.tsx
@@ -30,7 +30,6 @@ export type InkReadingEmbedHostParams = {
 export class InkReadingEmbedHost extends MarkdownRenderChild {
 	private reactRoot: Root | null = null;
 	private resizeObserver: ResizeObserver | null = null;
-	private pageResizeObserver: ResizeObserver | null = null;
 	private resizeContainerEl: HTMLElement | null = null;
 	private writingFileModifyRef: ReturnType<InkPlugin['app']['vault']['on']> | null = null;
 
@@ -40,10 +39,6 @@ export class InkReadingEmbedHost extends MarkdownRenderChild {
 	) {
 		super(containerEl);
 	}
-
-	private handleWindowResize = () => {
-		this.applyDimensions();
-	};
 
 	onload(): void {
 		this.containerEl.removeAttribute(INK_READING_MOUNTING_ATTR);
@@ -63,14 +58,11 @@ export class InkReadingEmbedHost extends MarkdownRenderChild {
 				onMount={(_embedEl, resizeContainerEl) => {
 					this.resizeContainerEl = resizeContainerEl;
 					this.attachResizeObserver(resizeContainerEl);
-					this.attachPageResizeObserver(resizeContainerEl);
 					this.applyDimensions();
 					void this.syncWritingAspectRatioFromFile();
 				}}
 			/>,
 		);
-
-		window.addEventListener('resize', this.handleWindowResize);
 
 		if (this.params.embedKind === 'writing' && this.params.embeddedFile) {
 			const writingFilePath = this.params.embeddedFile.path;
@@ -83,13 +75,10 @@ export class InkReadingEmbedHost extends MarkdownRenderChild {
 	}
 
 	onunload(): void {
-		window.removeEventListener('resize', this.handleWindowResize);
 		if (this.writingFileModifyRef) {
 			this.params.plugin.app.vault.offref(this.writingFileModifyRef);
 			this.writingFileModifyRef = null;
 		}
-		this.pageResizeObserver?.disconnect();
-		this.pageResizeObserver = null;
 		this.resizeContainerEl = null;
 		this.containerEl.removeAttribute(INK_READING_ACTIVE_ATTR);
 		this.containerEl.removeAttribute(INK_READING_MOUNTING_ATTR);
@@ -135,20 +124,12 @@ export class InkReadingEmbedHost extends MarkdownRenderChild {
 			this.applyDimensions();
 		});
 		this.resizeObserver.observe(resizeContainerEl);
-	}
-
-	private attachPageResizeObserver(resizeContainerEl: HTMLElement | null) {
-		if (!resizeContainerEl) return;
 
 		const pageEl = resizeContainerEl.closest('.markdown-preview-view')
 			?? resizeContainerEl.closest('.markdown-reading-view');
-		if (!(pageEl instanceof HTMLElement)) return;
-
-		this.pageResizeObserver?.disconnect();
-		this.pageResizeObserver = new ResizeObserver(() => {
-			this.applyDimensions();
-		});
-		this.pageResizeObserver.observe(pageEl);
+		if (pageEl instanceof HTMLElement && pageEl !== resizeContainerEl) {
+			this.resizeObserver.observe(pageEl);
+		}
 	}
 }
 

--- a/src/components/formats/current/reading-mode/register-reading-mode-ink-embeds.ts
+++ b/src/components/formats/current/reading-mode/register-reading-mode-ink-embeds.ts
@@ -24,6 +24,7 @@ const INK_READING_EMBED_KIND_DATA = 'inkEmbedKind';
 const INK_READING_FILE_PATH_DATA = 'inkFilePath';
 const INK_READING_EMBED_SETTINGS_DATA = 'inkEmbedSettings';
 const INK_READING_SOURCE_PATH_DATA = 'inkSourcePath';
+const INK_READING_HOST_SELECTOR = `.ddc_ink_reading-embed-host[${INK_READING_PROCESSED_ATTR}]`;
 
 export function registerReadingModeInkEmbeds(plugin: InkPlugin) {
 	// Run late so block containers include the full embed marker + Edit link row.
@@ -45,8 +46,12 @@ export function registerReadingModeInkEmbeds(plugin: InkPlugin) {
 	// Obsidian may reuse cached reading-view DOM when toggling LP ↔ RM. MarkdownRenderChild
 	// onunload clears React content but leaves host shells — remount when preview is shown again.
 	// When returning to Live Preview, rebuild CM embed widgets (they only refresh on down-scroll otherwise).
+	let refreshScheduled = false;
 	const scheduleReadingModeOrLivePreviewEmbedRefresh = () => {
+		if (refreshScheduled) return;
+		refreshScheduled = true;
 		queueMicrotask(() => {
+			refreshScheduled = false;
 			const markdownView = plugin.app.workspace.getActiveViewOfType(MarkdownView);
 			if (!markdownView) return;
 
@@ -72,6 +77,9 @@ function processReadingModeInkEmbedsInRoot(
 		rootEl,
 		context.sourcePath,
 	);
+	const containsMountedHost = rootEl.matches(INK_READING_HOST_SELECTOR)
+		|| rootEl.querySelector(INK_READING_HOST_SELECTOR) !== null;
+	if (candidates.length === 0 && !containsMountedHost) return;
 
 	// Replace last-to-first so earlier DOM ranges stay valid while iterating.
 	const sortedCandidates = [...candidates].sort((a, b) => {
@@ -106,7 +114,8 @@ function processReadingModeInkEmbedsInRoot(
 	// (active but no .ddc_ink_embed yet), re-mounts via plugin.addChild, and never unloads,
 	// leaving Obsidian's export progress bar stuck.
 	// Popout-safe: schedule on the window that owns this preview root.
-	window.requestAnimationFrame(() => {
+	const rootWindow = rootEl.ownerDocument.defaultView ?? window;
+	rootWindow.requestAnimationFrame(() => {
 		if (!isFullPageRoot) {
 			remountStaleReadingEmbedHostsInRoot(plugin, rootEl, context.sourcePath);
 		}
@@ -136,9 +145,7 @@ function remountStaleReadingEmbedHostsInRoot(
 	rootEl: HTMLElement,
 	sourcePath: string,
 ) {
-	const staleHostEls = [...rootEl.querySelectorAll<HTMLElement>(
-		`.ddc_ink_reading-embed-host[${INK_READING_PROCESSED_ATTR}]`,
-	)].filter((hostEl) => {
+	const staleHostEls = [...rootEl.querySelectorAll<HTMLElement>(INK_READING_HOST_SELECTOR)].filter((hostEl) => {
 		if (hostEl.hasAttribute(INK_READING_MOUNTING_ATTR)) return false;
 		if (!hostEl.hasAttribute(INK_READING_ACTIVE_ATTR)) return true;
 		return !hostEl.querySelector('.ddc_ink_embed');

--- a/src/components/formats/current/utils/buildFileStr.ts
+++ b/src/components/formats/current/utils/buildFileStr.ts
@@ -33,14 +33,12 @@ function buildInkCanvasFileStr(pageData: InkFileData): string {
         '</metadata>',
     ].join('\n');
 
-    const metadataPattern = /<metadata\b[^>]*>[\s\S]*?<\/metadata>/i;
-    if (metadataPattern.test(fileStr)) {
-        return fileStr.replace(metadataPattern, metadata);
-    }
+    const metadataPattern = /<metadata\b[^>]*>[\s\S]*?<\/metadata>/gi;
+    const fileWithoutMetadata = fileStr.replace(metadataPattern, '');
 
     const svgOpenPattern = /<svg\b[^>]*>/i;
-    if (svgOpenPattern.test(fileStr)) {
-        return fileStr.replace(svgOpenPattern, (svgOpen) => `${svgOpen}\n${metadata}`);
+    if (svgOpenPattern.test(fileWithoutMetadata)) {
+        return fileWithoutMetadata.replace(svgOpenPattern, (svgOpen) => `${svgOpen}\n${metadata}`);
     }
 
     return `<svg xmlns="http://www.w3.org/2000/svg">\n${metadata}\n</svg>`;

--- a/src/components/formats/current/utils/buildFileStr.ts
+++ b/src/components/formats/current/utils/buildFileStr.ts
@@ -20,42 +20,43 @@ export const buildFileStr = (pageData: InkFileData): string => {
 //////////////////////////
 
 function buildInkCanvasFileStr(pageData: InkFileData): string {
-    // For ink-canvas files, the svgString already contains the full SVG with
-    // <ink-canvas> metadata (produced by svg-export.ts). We just need to ensure
-    // the <ink> meta element is present with plugin-version and file-type.
-    let fileStr = pageData.svgString || '<svg></svg>';
+    // The ink-canvas renderer already gives us a complete SVG. Re-parsing and
+    // pretty-printing that multi-megabyte document on every autosave blocks the
+    // input thread in direct proportion to the number of strokes. Replace just
+    // the small metadata block and keep the rendered path markup untouched.
+    const fileStr = pageData.svgString || '<svg></svg>';
+    const snapshotJson = escapeXmlText(JSON.stringify(pageData.inkCanvas));
+    const metadata = [
+        '<metadata>',
+        `<ink plugin-version="${escapeXmlAttribute(String(pageData.meta.pluginVersion))}" file-type="${escapeXmlAttribute(pageData.meta.fileType)}"/>`,
+        `<ink-canvas version="${escapeXmlAttribute(INK_CANVAS_FORMAT_VERSION)}">${snapshotJson}</ink-canvas>`,
+        '</metadata>',
+    ].join('\n');
 
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(fileStr, 'image/svg+xml');
-    const svgElement = doc.documentElement;
-
-    // Remove existing metadata to rebuild cleanly
-    const existingMetadata = svgElement.getElementsByTagName('metadata');
-    while (existingMetadata.length > 0) {
-        existingMetadata[0].parentNode?.removeChild(existingMetadata[0]);
+    const metadataPattern = /<metadata\b[^>]*>[\s\S]*?<\/metadata>/i;
+    if (metadataPattern.test(fileStr)) {
+        return fileStr.replace(metadataPattern, metadata);
     }
 
-    const metadataElement = doc.createElement('metadata');
+    const svgOpenPattern = /<svg\b[^>]*>/i;
+    if (svgOpenPattern.test(fileStr)) {
+        return fileStr.replace(svgOpenPattern, (svgOpen) => `${svgOpen}\n${metadata}`);
+    }
 
-    // <ink> meta
-    const inkMetaElement = doc.createElement('ink');
-    inkMetaElement.setAttribute('plugin-version', String(pageData.meta.pluginVersion));
-    inkMetaElement.setAttribute('file-type', pageData.meta.fileType);
-    metadataElement.appendChild(inkMetaElement);
+    return `<svg xmlns="http://www.w3.org/2000/svg">\n${metadata}\n</svg>`;
+}
 
-    // <ink-canvas version="0.5.0"> JSON </ink-canvas>
-    const inkCanvasElement = doc.createElement('ink-canvas');
-    inkCanvasElement.setAttribute('version', INK_CANVAS_FORMAT_VERSION);
-    inkCanvasElement.textContent = JSON.stringify(pageData.inkCanvas, null, 2);
-    metadataElement.appendChild(inkCanvasElement);
+function escapeXmlText(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
 
-    svgElement.appendChild(metadataElement);
-
-    const serializedSvg = new XMLSerializer().serializeToString(svgElement);
-    return format(serializedSvg, {
-        indentation: '\t',
-        lineSeparator: '\n'
-    });
+function escapeXmlAttribute(value: string): string {
+    return escapeXmlText(value)
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
 }
 
 

--- a/src/components/formats/current/writing/writing-editor/writing-editor.tsx
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.tsx
@@ -1,7 +1,7 @@
 import './writing-editor.scss';
 import * as React from 'react';
 import { useRef } from 'react';
-import { TFile } from 'obsidian';
+import { Platform, TFile } from 'obsidian';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
 import InkPlugin from 'src/main';
@@ -39,6 +39,7 @@ import {
 } from 'src/logic/undo-redo/embedded-unified-undo';
 import { InkSvgCanvas } from 'src/ink-canvas/ink-svg-canvas';
 import { renderWritingStrokesToSvg } from 'src/ink-canvas/svg-export';
+import { resolveInkAutosaveDelayMs } from 'src/ink-canvas/autosave-delay';
 import { computeApproxContentMaxY } from 'src/ink-canvas/stroke-viewport-culling';
 import { migrateWritingFromTldraw } from 'src/ink-canvas/migrate-from-tldraw';
 import type { PageBounds } from './page-bounds';
@@ -107,7 +108,9 @@ export function WritingEditor(props: WritingEditorProps) {
 	const [booxConnected, setBooxConnected] = React.useState(false);
 	const resizePostProcessTimeoutRef = useRef<number>();
 	const shortDelayTimerRef = useRef<number>();
-	const longDelayTimerRef = useRef<number>();
+	const canvasInteractionActiveRef = useRef(false);
+	const hasUnsavedChangesRef = useRef(false);
+	const latestInvitingHeightRef = useRef(0);
 	const editorRef = useRef<InkCanvasEditor>();
 	const editorWrapperRefEl = useRef<HTMLDivElement>(null);
 	const websocketConnectedRef = useRef(false);
@@ -459,10 +462,20 @@ export function WritingEditor(props: WritingEditorProps) {
 	}
 
 	function handleStoreChange() {
+		hasUnsavedChangesRef.current = true;
 		queueSaves();
 		if (props.embedded) {
 			debouncedEmbedResizePostProcess();
 		}
+	}
+
+	function handleCanvasInteractionChange(active: boolean) {
+		canvasInteractionActiveRef.current = active;
+		if (active) {
+			resetTimers();
+			return;
+		}
+		if (hasUnsavedChangesRef.current) queueSaves();
 	}
 
 	function handleEmbedUndoStackPush() {
@@ -485,7 +498,7 @@ export function WritingEditor(props: WritingEditorProps) {
 			const editor = editorRef.current;
 			if (!editor || !props.embedded) return;
 			if (websocketConnectedRef.current && getBooxConnectionEnabled()) return;
-			const invitingHeight = getInvitingHeightFromEditor(editor);
+			const invitingHeight = latestInvitingHeightRef.current || getInvitingHeightFromEditor(editor);
 			if (!shouldResizeForNewHeight(
 				invitingHeight,
 				curHeightRef.current,
@@ -499,6 +512,7 @@ export function WritingEditor(props: WritingEditorProps) {
 	}
 
 	function handlePageHeightChange(candidateHeightPx: number) {
+		latestInvitingHeightRef.current = candidateHeightPx;
 		applyPageHeightChange(candidateHeightPx, false);
 	}
 
@@ -508,7 +522,10 @@ export function WritingEditor(props: WritingEditorProps) {
 
 		const lineHeight = writingLineHeightRef.current;
 		const bufferLines = props.plugin.settings.writingBufferLines;
-		const invitingFromContent = getInvitingHeightFromEditor(editor);
+		const invitingFromContent = candidateHeightPx > 0
+			? candidateHeightPx
+			: getInvitingHeightFromEditor(editor);
+		latestInvitingHeightRef.current = invitingFromContent;
 
 		if (props.embedded) {
 			const skipAutoResize = !forceNextPageHeightChangeRef.current
@@ -587,20 +604,24 @@ export function WritingEditor(props: WritingEditorProps) {
 
 	function queueSaves() {
 		resetTimers();
+		if (canvasInteractionActiveRef.current) return;
+		const delayMs = resolveInkAutosaveDelayMs(Platform, WRITE_SHORT_DELAY_MS, WRITE_LONG_DELAY_MS);
 		shortDelayTimerRef.current = window.setTimeout(() => {
 			void incrementalSave();
-		}, WRITE_SHORT_DELAY_MS);
-		longDelayTimerRef.current = window.setTimeout(() => {
-			void completeSave();
-		}, WRITE_LONG_DELAY_MS);
+		}, delayMs);
 	}
 
 	async function incrementalSave() {
+		if (canvasInteractionActiveRef.current) {
+			queueSaves();
+			return;
+		}
 		const editor = editorRef.current;
 		if (!editor) return;
 		verbose('incrementalSave (ink-canvas writing)');
 		const snapshot = editor.getSnapshot();
 		const svgString = renderWritingStrokesToSvg(snapshot.strokes, snapshot, WRITING_PAGE_WIDTH);
+		hasUnsavedChangesRef.current = false;
 		props.save(buildInkCanvasWritingFileData({ inkCanvasSnapshot: snapshot, svgString }));
 	}
 
@@ -610,13 +631,13 @@ export function WritingEditor(props: WritingEditorProps) {
 		verbose('completeSave (ink-canvas writing)');
 		const snapshot = editor.getSnapshot();
 		const svgString = renderWritingStrokesToSvg(snapshot.strokes, snapshot, WRITING_PAGE_WIDTH);
+		hasUnsavedChangesRef.current = false;
 		props.save(buildInkCanvasWritingFileData({ inkCanvasSnapshot: snapshot, svgString }));
 	}
 
 	function resetTimers() {
 		cancelDelayedBooxResizePostProcess();
 		window.clearTimeout(shortDelayTimerRef.current);
-		window.clearTimeout(longDelayTimerRef.current);
 	}
 
 	async function fetchFileData() {
@@ -929,6 +950,7 @@ export function WritingEditor(props: WritingEditorProps) {
 			writingBufferLines={props.plugin.settings.writingBufferLines}
 			onEditorReady={handleEditorReady}
 			onChange={handleStoreChange}
+			onInteractionChange={handleCanvasInteractionChange}
 			onEmbedUndoStackPush={handleEmbedUndoStackPush}
 			onPageHeightChange={handlePageHeightChange}
 			isEmbedded={props.embedded}

--- a/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.scss
+++ b/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.scss
@@ -1,5 +1,3 @@
-@use '../../../../shared/ink-svg-preview-theme';
-
 .ddc_ink_writing-embed-preview {
     pointer-events: none;
 

--- a/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.tsx
+++ b/src/components/formats/current/writing/writing-embed-preview/writing-embed-preview.tsx
@@ -97,7 +97,7 @@ export const WritingEmbedPreview: React.FC<WritingEmbedPreviewProps> = (props) =
             {!isImg && (<>
                 <SVG
                     src={fileSrc}
-                    cacheRequests={false}
+                    cacheRequests={true}
                     key={fileSrc}
                     style={{
                         width: '100%',
@@ -118,8 +118,7 @@ export const WritingEmbedPreview: React.FC<WritingEmbedPreviewProps> = (props) =
     ///////////////////
 
     function onLoad() {
-        // Slight delay on transition because otherwise a flicker is sometimes seen
-        window.setTimeout(() => {}, 100);
+        // Kept as a callback for parity with drawing previews.
     }
 
     function refreshSrc() {

--- a/src/components/shared/ink-svg-preview-theme.scss
+++ b/src/components/shared/ink-svg-preview-theme.scss
@@ -2,6 +2,17 @@
 // and native SVG leaf after ensureThemedNativeInkSvgView mounts a themed host).
 // SVG must be in the DOM (not img) for these rules to apply.
 
+// Reading mode initially renders Ink attachments as native images. Large SVGs can
+// remain in that state while the post-processor mounts a theme-aware inline SVG,
+// and a missed post-process should still be readable. Ink exports are monochrome,
+// so invert only the native image fallback in dark mode. The selector excludes
+// the React preview hosts below, which use Obsidian's exact text colour instead.
+.theme-dark .markdown-preview-view {
+	img:is([alt="InkWriting"], [alt="InkDrawing"]) {
+		filter: invert(1);
+	}
+}
+
 .ddc_ink_writing-embed-preview,
 .ddc_ink_drawing-embed-preview {
 	// !important beats baked fill="#000000" presentation attributes in saved SVGs.

--- a/src/ink-canvas/autosave-delay.ts
+++ b/src/ink-canvas/autosave-delay.ts
@@ -1,0 +1,16 @@
+export type InkPlatformFlags = {
+	isMobile?: boolean;
+	isMobileApp?: boolean;
+	isIosApp?: boolean;
+};
+
+/** Mobile WebViews need a longer quiet period before serializing large Ink SVGs. */
+export function resolveInkAutosaveDelayMs(
+	platform: InkPlatformFlags,
+	desktopDelayMs: number,
+	mobileDelayMs: number,
+): number {
+	return platform.isMobile || platform.isMobileApp || platform.isIosApp
+		? mobileDelayMs
+		: desktopDelayMs;
+}

--- a/src/ink-canvas/ink-svg-canvas.tsx
+++ b/src/ink-canvas/ink-svg-canvas.tsx
@@ -1,8 +1,6 @@
 import './ink-svg-canvas.scss';
 import React, { useEffect, useLayoutEffect, useRef, useCallback, useState, memo } from 'react';
-import { getStroke } from 'perfect-freehand';
-import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
-import { StrokeStore } from './stroke-store';
+import { StrokeStore, type StrokeStoreChange } from './stroke-store';
 import { UndoManager } from './undo-manager';
 import { panByScreenDelta, zoomAtPoint, clampZoom, fitBoundsToViewport, adjustCameraToPreservePagePointAtScreenTargets, adjustCameraToPreserveViewportCenter, screenToPage as screenToPageFn, getRightDragZoomDelta } from './camera';
 import { createPanMomentumController, createModifierWheelZoomDirectionResolver, isTrackpadWheel, type PanMomentumController } from './pan-momentum';
@@ -28,12 +26,13 @@ import { useStrokeInputTreatAs } from 'src/logic/device-settings/use-stroke-inpu
 import { useResolvedStrokeInputTreatAs } from 'src/logic/device-settings/use-resolved-stroke-input-treat-as';
 import { useBooxConnectionEnabled } from 'src/logic/device-settings/use-boox-connection-enabled';
 import { DEFAULT_SETTINGS } from 'src/types/plugin-settings';
-import { toStrokeOptions, DEFAULT_STROKE_STYLE } from './types';
+import { DEFAULT_STROKE_STYLE } from './types';
 import type { InkTool, InkStrokeStyle, CameraState, InkCanvasSnapshot, InkCanvasEditor, InkStroke } from './types';
 import type { DrawToolContext } from './tools/draw-tool';
 import type { EraseToolContext } from './tools/erase-tool';
 import type { SelectToolContext } from './tools/select-tool';
 import { InkAdaptiveGrid, INK_GRID_BOOX_ZOOM_FADE_SCALE } from './ink-adaptive-grid';
+import { getRenderedStrokeData } from './rendered-stroke-cache';
 
 type LastCanvasPointerState = {
 	clientX: number;
@@ -66,6 +65,8 @@ export interface InkSvgCanvasProps {
 	initialSnapshot?: InkCanvasSnapshot;
 	onEditorReady?: (editor: InkCanvasEditor) => void;
 	onChange?: () => void;
+	/** Pauses expensive persistence work while a pen/pointer interaction is active. */
+	onInteractionChange?: (active: boolean) => void;
 	/** Fired when a new undoable canvas command is executed (stroke, erase, move, etc.). */
 	onEmbedUndoStackPush?: () => void;
 	/** Emits whenever camera changes (pan/zoom/setCamera). */
@@ -111,6 +112,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	const pageWidth = props.pageWidth ?? WRITING_PAGE_WIDTH;
 	const writingBufferLines = props.writingBufferLines ?? 3;
 	const writingLineHeight = props.initialSnapshot?.writingLineHeight ?? WRITING_LINE_HEIGHT;
+	const contentMaxYRef = useRef(0);
 
 	const canvasWrapperRef = useRef<HTMLDivElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -124,6 +126,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		const contentHeight = strokes.length > 0
 			? computeApproxContentMaxY(strokes)
 			: 0;
+		contentMaxYRef.current = contentHeight;
 		return cropWritingStrokeHeightInvitingly(contentHeight, writingBufferLines, writingLineHeight);
 	}
 
@@ -180,6 +183,8 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	gridEnabledRef.current = gridEnabled;
 	const onChangeRef = useRef(props.onChange);
 	onChangeRef.current = props.onChange;
+	const onInteractionChangeRef = useRef(props.onInteractionChange);
+	onInteractionChangeRef.current = props.onInteractionChange;
 	const onEmbedUndoStackPushRef = useRef(props.onEmbedUndoStackPush);
 	onEmbedUndoStackPushRef.current = props.onEmbedUndoStackPush;
 	const setGridEnabledHandlerRef = useRef<(enabled: boolean) => void>(() => {});
@@ -306,21 +311,29 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	// Subscribe to store changes to re-render strokes
 	useEffect(() => {
-		const unsubStore = storeRef.current.subscribe(() => {
-			// Invalidate cull bounds + path `d` — points/style may have changed; store still holds every stroke.
-			strokeBoundsCacheRef.current.clear();
-			strokePathDCacheRef.current.clear();
+		const unsubStore = storeRef.current.subscribe((change) => {
+			// Only invalidate cache entries touched by this mutation.
+			invalidateStrokeCaches(change);
 			forceRender(n => n + 1);
 			props.onChange?.();
 
 			if (writingMode) {
-				const allStrokes = storeRef.current.getAll();
+				if (change.type === 'add' || change.type === 'addMany') {
+					for (const id of change.ids) {
+						const stroke = storeRef.current.getById(id);
+						if (!stroke) continue;
+						const bounds = computeApproxStrokePageBounds(stroke);
+						strokeBoundsCacheRef.current.set(id, bounds);
+						if (bounds.maxY > contentMaxYRef.current) contentMaxYRef.current = bounds.maxY;
+					}
+				} else if (change.type === 'clear') {
+					contentMaxYRef.current = 0;
+				} else {
+					contentMaxYRef.current = computeApproxContentMaxY(storeRef.current.getAll());
+				}
 				const lh = props.initialSnapshot?.writingLineHeight ?? WRITING_LINE_HEIGHT;
-				const contentHeight = allStrokes.length > 0
-					? computeApproxContentMaxY(allStrokes)
-					: 0;
 				const candidateHeight = cropWritingStrokeHeightInvitingly(
-					contentHeight,
+					contentMaxYRef.current,
 					writingBufferLines,
 					lh,
 				);
@@ -335,6 +348,20 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		});
 		return () => { unsubStore(); unsubUndo(); };
 	}, []);  
+
+	function invalidateStrokeCaches(change: StrokeStoreChange): void {
+		if (change.type === 'clear' || change.type === 'replaceAll') {
+			strokeBoundsCacheRef.current.clear();
+			strokePathDCacheRef.current.clear();
+			return;
+		}
+
+		for (const id of change.ids) {
+			strokeBoundsCacheRef.current.delete(id);
+			// Moving a stroke only changes its transform; its path data stays valid.
+			if (change.type !== 'updateOffsets') strokePathDCacheRef.current.delete(id);
+		}
+	}
 
 	// Re-cull when the note scroller or window moves the canvas on/off screen (embeds + dedicated).
 	useEffect(() => {
@@ -725,6 +752,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		// Touch input: two-finger gestures are handled by the native touch listener.
 		// Single-finger touch is ignored unless finger drawing is active.
 		if (e.pointerType === 'touch' && !isFingerDrawingActiveRef.current) return;
+		onInteractionChangeRef.current?.(true);
 
 		recordCanvasPointer(e);
 		isPointerOverCanvasRef.current = true;
@@ -847,6 +875,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	const handlePointerUp = useCallback((e: React.PointerEvent) => {
 		if (e.pointerType === 'touch' && !isFingerDrawingActiveRef.current) return;
+		onInteractionChangeRef.current?.(false);
 
 		recordCanvasPointer(e);
 
@@ -878,6 +907,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	const handlePointerCancel = useCallback((e: React.PointerEvent) => {
 		if (e.pointerType === 'touch' && !isFingerDrawingActiveRef.current) return;
+		onInteractionChangeRef.current?.(false);
 
 		recordCanvasPointer(e);
 
@@ -1303,8 +1333,7 @@ const StrokePath = memo(function StrokePath(props: StrokePathProps): React.JSX.E
 	// cache clear + remount) reuse `d` when the id is still populated; offset is transform-only.
 	let d = pathDCache.get(stroke.id);
 	if (d === undefined) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		d = getSvgPathFromStroke(outlinePoints);
+		d = getRenderedStrokeData(stroke).pathD;
 		pathDCache.set(stroke.id, d);
 	}
 

--- a/src/ink-canvas/rendered-stroke-cache.ts
+++ b/src/ink-canvas/rendered-stroke-cache.ts
@@ -1,0 +1,48 @@
+import { getStroke } from 'perfect-freehand';
+import type { InkStroke } from './types';
+import { toStrokeOptions } from './types';
+import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
+
+export type RenderedStrokeBounds = {
+	minX: number;
+	minY: number;
+	maxX: number;
+	maxY: number;
+};
+
+export type RenderedStrokeData = {
+	pathD: string;
+	bounds: RenderedStrokeBounds;
+};
+
+// Strokes are immutable in normal use. A WeakMap lets editor rendering and
+// autosave share the expensive perfect-freehand outline without retaining
+// deleted strokes.
+const renderedStrokeCache = new WeakMap<InkStroke, RenderedStrokeData>();
+
+export function getRenderedStrokeData(stroke: InkStroke): RenderedStrokeData {
+	const cached = renderedStrokeCache.get(stroke);
+	if (cached) return cached;
+
+	const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
+	let minX = Infinity;
+	let minY = Infinity;
+	let maxX = -Infinity;
+	let maxY = -Infinity;
+
+	for (const [x, y] of outlinePoints) {
+		if (x < minX) minX = x;
+		if (y < minY) minY = y;
+		if (x > maxX) maxX = x;
+		if (y > maxY) maxY = y;
+	}
+
+	const data: RenderedStrokeData = {
+		pathD: getSvgPathFromStroke(outlinePoints),
+		bounds: Number.isFinite(minX)
+			? { minX, minY, maxX, maxY }
+			: { minX: 0, minY: 0, maxX: 0, maxY: 0 },
+	};
+	renderedStrokeCache.set(stroke, data);
+	return data;
+}

--- a/src/ink-canvas/stroke-store.ts
+++ b/src/ink-canvas/stroke-store.ts
@@ -3,7 +3,11 @@ import type { InkStroke } from './types';
 ///////////////////////////
 ///////////////////////////
 
-export type StrokeStoreListener = () => void;
+export type StrokeStoreChange =
+	| { type: 'add' | 'addMany' | 'remove' | 'updateOffsets'; ids: string[] }
+	| { type: 'clear' | 'replaceAll'; ids: [] };
+
+export type StrokeStoreListener = (change: StrokeStoreChange) => void;
 
 /**
  * Reactive store for ink strokes. Maintains an ordered list of strokes and
@@ -20,16 +24,16 @@ export class StrokeStore {
 		return () => { this.listeners.delete(listener); };
 	}
 
-	private notify(): void {
+	private notify(change: StrokeStoreChange): void {
 		for (const listener of this.listeners) {
-			listener();
+			listener(change);
 		}
 	}
 
 	add(stroke: InkStroke): void {
 		this.strokes.set(stroke.id, stroke);
 		this.insertionOrder.push(stroke.id);
-		this.notify();
+		this.notify({ type: 'add', ids: [stroke.id] });
 	}
 
 	addMany(strokesArr: InkStroke[]): void {
@@ -37,7 +41,7 @@ export class StrokeStore {
 			this.strokes.set(stroke.id, stroke);
 			this.insertionOrder.push(stroke.id);
 		}
-		this.notify();
+		this.notify({ type: 'addMany', ids: strokesArr.map((stroke) => stroke.id) });
 	}
 
 	remove(ids: string[]): void {
@@ -46,7 +50,7 @@ export class StrokeStore {
 			this.strokes.delete(id);
 		}
 		this.insertionOrder = this.insertionOrder.filter(id => !idSet.has(id));
-		this.notify();
+		this.notify({ type: 'remove', ids: [...ids] });
 	}
 
 	/** Update the offset of one or more strokes (used by the select-and-move tool). */
@@ -57,7 +61,7 @@ export class StrokeStore {
 				this.strokes.set(id, { ...stroke, offset });
 			}
 		}
-		this.notify();
+		this.notify({ type: 'updateOffsets', ids: Array.from(offsets.keys()) });
 	}
 
 	getById(id: string): InkStroke | undefined {
@@ -82,7 +86,7 @@ export class StrokeStore {
 	clear(): void {
 		this.strokes.clear();
 		this.insertionOrder = [];
-		this.notify();
+		this.notify({ type: 'clear', ids: [] });
 	}
 
 	/** Replace all content with the given strokes (used for snapshot restore). */
@@ -93,6 +97,6 @@ export class StrokeStore {
 			this.strokes.set(stroke.id, stroke);
 			this.insertionOrder.push(stroke.id);
 		}
-		this.notify();
+		this.notify({ type: 'replaceAll', ids: [] });
 	}
 }

--- a/src/ink-canvas/svg-export.ts
+++ b/src/ink-canvas/svg-export.ts
@@ -107,6 +107,13 @@ function renderStrokePathsAndBounds(strokes: InkStroke[]): {
 	pathsMarkup: string;
 	bounds: StrokeBounds;
 } {
+	if (strokes.length === 0) {
+		return {
+			pathsMarkup: '',
+			bounds: { minX: 0, minY: 0, maxX: 0, maxY: 0, width: 0, height: 0 },
+		};
+	}
+
 	let minX = Infinity;
 	let minY = Infinity;
 	let maxX = -Infinity;

--- a/src/ink-canvas/svg-export.ts
+++ b/src/ink-canvas/svg-export.ts
@@ -1,4 +1,3 @@
-import { getStroke } from 'perfect-freehand';
 import {
 	DEFAULT_CONTENT_COLOUR_PRIMARY_STROKE,
 	DEFAULT_CONTENT_COLOUR_WRITING_LINE,
@@ -6,9 +5,8 @@ import {
 	INK_SVG_WRITING_LINE_CLASS,
 } from 'src/default-content-colours';
 import { INK_CANVAS_FORMAT_VERSION, WRITING_LINE_HEIGHT, WRITING_MIN_PAGE_HEIGHT } from 'src/constants';
-import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
 import type { InkStroke, InkCanvasSnapshot } from './types';
-import { toStrokeOptions } from './types';
+import { getRenderedStrokeData } from './rendered-stroke-cache';
 ///////////////////////////
 ///////////////////////////
 
@@ -26,7 +24,8 @@ export function renderStrokesToSvg(
 		return buildSvgString('', '0 0 1 1', snapshotJson);
 	}
 
-	const bounds = computeStrokesBounds(strokes);
+	const rendered = renderStrokePathsAndBounds(strokes);
+	const bounds = rendered.bounds;
 	const viewBox = [
 		bounds.minX - padding,
 		bounds.minY - padding,
@@ -34,14 +33,7 @@ export function renderStrokesToSvg(
 		bounds.height + padding * 2,
 	].join(' ');
 
-	let pathsMarkup = '';
-	for (const stroke of strokes) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		const d = getSvgPathFromStroke(outlinePoints);
-		pathsMarkup += buildStrokePathMarkup(d, stroke.offset.x, stroke.offset.y);
-	}
-
-	return buildSvgString(pathsMarkup, viewBox, snapshotJson);
+	return buildSvgString(rendered.pathsMarkup, viewBox, snapshotJson);
 }
 
 /**
@@ -55,10 +47,10 @@ export function renderWritingStrokesToSvg(
 	padding: number = 0,
 ): string {
 	const lineHeight = snapshot.writingLineHeight ?? WRITING_LINE_HEIGHT;
+	const rendered = renderStrokePathsAndBounds(strokes);
 	let height = WRITING_MIN_PAGE_HEIGHT;
 	if (strokes.length > 0) {
-		const bounds = computeStrokesBounds(strokes);
-		const numFilledLines = Math.ceil((bounds.maxY + padding) / lineHeight);
+		const numFilledLines = Math.ceil((rendered.bounds.maxY + padding) / lineHeight);
 		height = Math.max((numFilledLines + 0.5) * lineHeight, WRITING_MIN_PAGE_HEIGHT);
 	}
 
@@ -70,15 +62,8 @@ export function renderWritingStrokesToSvg(
 		guideMarkup += `<line x1="${margin}" y1="${y}" x2="${pageWidth - margin}" y2="${y}" stroke="${DEFAULT_CONTENT_COLOUR_WRITING_LINE}" stroke-opacity="0.5" class="${INK_SVG_WRITING_LINE_CLASS}" />\n`;
 	}
 
-	let pathsMarkup = '';
-	for (const stroke of strokes) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		const d = getSvgPathFromStroke(outlinePoints);
-		pathsMarkup += buildStrokePathMarkup(d, stroke.offset.x, stroke.offset.y);
-	}
-
 	const viewBox = `0 0 ${pageWidth} ${height}`;
-	return buildSvgString(guideMarkup + pathsMarkup, viewBox, snapshot);
+	return buildSvgString(guideMarkup + rendered.pathsMarkup, viewBox, snapshot);
 }
 
 
@@ -104,19 +89,47 @@ function buildSvgString(
 	return [
 		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}">`,
 		`<metadata>`,
-		`<ink-canvas version="${INK_CANVAS_FORMAT_VERSION}">${escapeXml(metadataJson)}</ink-canvas>`,
+		`<ink-canvas version="${INK_CANVAS_FORMAT_VERSION}">${escapeXmlText(metadataJson)}</ink-canvas>`,
 		`</metadata>`,
 		pathsMarkup,
 		`</svg>`,
 	].join('\n');
 }
 
-function escapeXml(str: string): string {
+function escapeXmlText(str: string): string {
 	return str
 		.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
+		.replace(/>/g, '&gt;');
+}
+
+function renderStrokePathsAndBounds(strokes: InkStroke[]): {
+	pathsMarkup: string;
+	bounds: StrokeBounds;
+} {
+	let minX = Infinity;
+	let minY = Infinity;
+	let maxX = -Infinity;
+	let maxY = -Infinity;
+	let pathsMarkup = '';
+
+	for (const stroke of strokes) {
+		const rendered = getRenderedStrokeData(stroke);
+		const strokeMinX = rendered.bounds.minX + stroke.offset.x;
+		const strokeMinY = rendered.bounds.minY + stroke.offset.y;
+		const strokeMaxX = rendered.bounds.maxX + stroke.offset.x;
+		const strokeMaxY = rendered.bounds.maxY + stroke.offset.y;
+		if (strokeMinX < minX) minX = strokeMinX;
+		if (strokeMinY < minY) minY = strokeMinY;
+		if (strokeMaxX > maxX) maxX = strokeMaxX;
+		if (strokeMaxY > maxY) maxY = strokeMaxY;
+		pathsMarkup += buildStrokePathMarkup(rendered.pathD, stroke.offset.x, stroke.offset.y);
+	}
+
+	return {
+		pathsMarkup,
+		bounds: { minX, minY, maxX, maxY, width: maxX - minX, height: maxY - minY },
+	};
 }
 
 
@@ -139,17 +152,15 @@ export function computeStrokesBounds(strokes: InkStroke[]): StrokeBounds {
 	let maxY = -Infinity;
 
 	for (const stroke of strokes) {
-		// Compute the outline to get the true rendered bounds
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-
-		for (const [px, py] of outlinePoints) {
-			const x = px + stroke.offset.x;
-			const y = py + stroke.offset.y;
-			if (x < minX) minX = x;
-			if (y < minY) minY = y;
-			if (x > maxX) maxX = x;
-			if (y > maxY) maxY = y;
-		}
+		const rendered = getRenderedStrokeData(stroke);
+		const strokeMinX = rendered.bounds.minX + stroke.offset.x;
+		const strokeMinY = rendered.bounds.minY + stroke.offset.y;
+		const strokeMaxX = rendered.bounds.maxX + stroke.offset.x;
+		const strokeMaxY = rendered.bounds.maxY + stroke.offset.y;
+		if (strokeMinX < minX) minX = strokeMinX;
+		if (strokeMinY < minY) minY = strokeMinY;
+		if (strokeMaxX > maxX) maxX = strokeMaxX;
+		if (strokeMaxY > maxY) maxY = strokeMaxY;
 	}
 
 	return {

--- a/src/logic/utils/ink-file-has-strokes.ts
+++ b/src/logic/utils/ink-file-has-strokes.ts
@@ -17,7 +17,37 @@ export function getInkStrokesFromSvg(svgString: string): InkStroke[] {
 }
 
 export function inkFileHasStrokes(svgString: string): boolean {
+	const inkCanvasResult = sniffInkCanvasHasStrokes(svgString);
+	if (inkCanvasResult !== null) return inkCanvasResult;
+
 	return getInkStrokesFromSvg(svgString).length > 0;
+}
+
+/**
+ * Read only the `strokes` array opener from current ink-canvas metadata.
+ * This avoids XML parsing and JSON-decoding every point in multi-megabyte files
+ * when a locked preview only needs to distinguish an empty canvas.
+ */
+export function sniffInkCanvasHasStrokes(svgString: string): boolean | null {
+	const inkCanvasStart = svgString.search(/<ink-canvas\b/i);
+	if (inkCanvasStart === -1) return null;
+
+	const inkCanvasEnd = svgString.indexOf('</ink-canvas>', inkCanvasStart);
+	if (inkCanvasEnd === -1) return null;
+
+	const strokesKey = svgString.indexOf('"strokes"', inkCanvasStart);
+	if (strokesKey === -1 || strokesKey >= inkCanvasEnd) return null;
+
+	const arrayStart = svgString.indexOf('[', strokesKey + '"strokes"'.length);
+	if (arrayStart === -1 || arrayStart >= inkCanvasEnd) return null;
+
+	let firstValueIndex = arrayStart + 1;
+	while (firstValueIndex < inkCanvasEnd && /\s/.test(svgString[firstValueIndex])) {
+		firstValueIndex += 1;
+	}
+
+	if (firstValueIndex >= inkCanvasEnd) return null;
+	return svgString[firstValueIndex] !== ']';
 }
 
 /** When locked and empty, show frame/lines/background regardless of the matching setting. */

--- a/src/logic/utils/svg-edit-button.scss
+++ b/src/logic/utils/svg-edit-button.scss
@@ -1,5 +1,3 @@
-@use '../../components/shared/ink-svg-preview-theme';
-
 .ddc_ink_svg-view-content--anchor {
     position: relative;
 }

--- a/src/logic/utils/use-ink-file-has-strokes.ts
+++ b/src/logic/utils/use-ink-file-has-strokes.ts
@@ -8,6 +8,7 @@ import { inkFileHasStrokes } from 'src/logic/utils/ink-file-has-strokes';
  */
 export function useInkFileHasStrokes(file: TFile | null, vault: Vault): boolean | null {
 	const [hasStrokes, setHasStrokes] = useState<boolean | null>(null);
+	const fileMtime = file?.stat.mtime;
 
 	useEffect(() => {
 		if (!file) {
@@ -20,7 +21,7 @@ export function useInkFileHasStrokes(file: TFile | null, vault: Vault): boolean 
 
 		async function refresh() {
 			try {
-				const svgString = await vault.read(inkFile);
+				const svgString = await vault.cachedRead(inkFile);
 				if (!cancelled) {
 					setHasStrokes(inkFileHasStrokes(svgString));
 				}
@@ -33,18 +34,13 @@ export function useInkFileHasStrokes(file: TFile | null, vault: Vault): boolean 
 
 		void refresh();
 
-		const onModify = (modifiedFile: TFile) => {
-			if (modifiedFile.path !== inkFile.path) return;
-			void refresh();
-		};
-		const eventRef = vault.on('modify', onModify);
-
 		return () => {
 			cancelled = true;
-			// @ts-ignore - offref exists in Obsidian API
-			vault.offref(eventRef);
 		};
-	}, [file, vault]);
+	// The preview component already subscribes to vault modifications and changes
+	// its mtime-busted source URL. Reuse that render instead of registering a
+	// second listener for every Ink embed.
+	}, [file, fileMtime, vault]);
 
 	return hasStrokes;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import './ddc-library/settings-styles.scss';
+import './components/shared/ink-svg-preview-theme.scss';
 import { App, Editor, Notice, Platform, Plugin, addIcon } from 'obsidian';
 import { DEFAULT_SETTINGS, PluginSettings } from 'src/types/plugin-settings';
 import { registerSettingsTab } from './components/dom-components/tabs/settings-tab/settings-tab';

--- a/tests/components/formats/current/drawing/DrawingEmbedPreview.test.tsx
+++ b/tests/components/formats/current/drawing/DrawingEmbedPreview.test.tsx
@@ -16,7 +16,7 @@ jest.mock('src/stores/global-store', () => ({
 			app: {
 				vault: {
 					getResourcePath: () => '/vault/drawing.svg',
-					read: (...args: unknown[]) => mockVaultRead(...args),
+					cachedRead: (...args: unknown[]) => mockVaultRead(...args),
 					on: jest.fn(() => jest.fn()),
 					offref: jest.fn(),
 				},

--- a/tests/components/formats/current/utils/BuildFileStr.test.ts
+++ b/tests/components/formats/current/utils/BuildFileStr.test.ts
@@ -110,6 +110,19 @@ describe('buildFileStr — ink-canvas serialization', () => {
 		expect(result).not.toContain('stale');
 	});
 
+	test('removes every stale metadata block before inserting the current snapshot', () => {
+		const data = makeInkCanvasFileData();
+		data.svgString = data.svgString.replace(
+			'<path id="kept"/>',
+			'<metadata><ink-canvas>also-stale</ink-canvas></metadata><path id="kept"/>',
+		);
+
+		const result = buildFileStr(data);
+		expect(result.match(/<metadata\b/g)).toHaveLength(1);
+		expect(result).not.toContain('also-stale');
+		expect(result).toContain('<path id="kept"/>');
+	});
+
 	test('uses compact XML-safe JSON that survives a round trip', () => {
 		const result = buildFileStr(makeInkCanvasFileData());
 		const parsed = extractInkJsonFromSvg(result);

--- a/tests/components/formats/current/utils/BuildFileStr.test.ts
+++ b/tests/components/formats/current/utils/BuildFileStr.test.ts
@@ -3,6 +3,7 @@ import { buildFileStr } from 'src/components/formats/current/utils/buildFileStr'
 import { extractInkJsonFromSvg } from 'src/logic/utils/extractInkJsonFromSvg';
 import { InkFileData } from 'src/components/formats/current/types/file-data';
 import { PLUGIN_VERSION, TLDRAW_VERSION } from 'src/constants';
+import { DEFAULT_STROKE_STYLE, type InkCanvasSnapshot } from 'src/ink-canvas/types';
 
 ////////
 ////////
@@ -34,6 +35,30 @@ function makeDrawingFileData(): InkFileData {
 		},
 		tldraw: minimalSnapshot,
 		svgString: '<svg xmlns="http://www.w3.org/2000/svg"><defs/></svg>',
+	};
+}
+
+function makeInkCanvasFileData(): InkFileData {
+	const inkCanvas: InkCanvasSnapshot = {
+		version: 1,
+		strokes: [{
+			id: 'stroke<&',
+			points: [[0, 0, 0.5], [10, 10, 0.7]],
+			style: { ...DEFAULT_STROKE_STYLE },
+			offset: { x: 0, y: 0 },
+		}],
+		gridEnabled: false,
+		writingLineHeight: 150,
+	};
+	return {
+		meta: {
+			pluginVersion: PLUGIN_VERSION,
+			tldrawVersion: '',
+			fileType: 'inkWriting',
+		},
+		tldraw: minimalSnapshot,
+		inkCanvas,
+		svgString: '<svg xmlns="http://www.w3.org/2000/svg"><metadata><ink-canvas>stale</ink-canvas></metadata><path id="kept"/></svg>',
 	};
 }
 
@@ -73,6 +98,27 @@ describe('buildFileStr — writing-line-height attribute', () => {
 	test('always includes the tldraw element', () => {
 		const result = buildFileStr(makeWritingFileData(150));
 		expect(result).toContain('<tldraw');
+	});
+});
+
+describe('buildFileStr — ink-canvas serialization', () => {
+	test('replaces only metadata and keeps rendered SVG markup intact', () => {
+		const result = buildFileStr(makeInkCanvasFileData());
+
+		expect(result.match(/<metadata\b/g)).toHaveLength(1);
+		expect(result).toContain('<path id="kept"/>');
+		expect(result).not.toContain('stale');
+	});
+
+	test('uses compact XML-safe JSON that survives a round trip', () => {
+		const result = buildFileStr(makeInkCanvasFileData());
+		const parsed = extractInkJsonFromSvg(result);
+
+		expect(result).toContain('"version":1');
+		expect(result).not.toContain('\n  "version"');
+		expect(result).toContain('stroke&lt;&amp;');
+		expect(parsed?.inkCanvas?.strokes[0].id).toBe('stroke<&');
+		expect(parsed?.inkCanvas?.writingLineHeight).toBe(150);
 	});
 });
 

--- a/tests/components/formats/current/writing/WritingEmbedPreview.test.tsx
+++ b/tests/components/formats/current/writing/WritingEmbedPreview.test.tsx
@@ -38,7 +38,7 @@ const makePlugin = (vaultRead: jest.Mock) => ({
 	app: {
 		vault: {
 			getResourcePath: jest.fn(() => '/vault/writing.svg'),
-			read: vaultRead,
+			cachedRead: vaultRead,
 			on: jest.fn(() => jest.fn()),
 			offref: jest.fn(),
 		},

--- a/tests/e2e/reading-mode.e2e.ts
+++ b/tests/e2e/reading-mode.e2e.ts
@@ -90,7 +90,7 @@ describe("Reading mode ink embeds", function () {
 
 		expect(fillsByTheme).not.toBeNull();
 		expect(fillsByTheme!.lightFill).not.toBe(fillsByTheme!.darkFill);
-		// Baked SVG uses #000000 — themed display must not stay hardcoded black in both themes.
-		expect(fillsByTheme!.lightFill === "rgb(0, 0, 0)" && fillsByTheme!.darkFill === "rgb(0, 0, 0)").toBe(false);
+		// Baked SVG uses #000000; dark Reading mode must override it to a visible colour.
+		expect(fillsByTheme!.darkFill).not.toBe("rgb(0, 0, 0)");
 	});
 });

--- a/tests/ink-canvas/autosave-delay.test.ts
+++ b/tests/ink-canvas/autosave-delay.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from '@jest/globals';
+import { resolveInkAutosaveDelayMs } from 'src/ink-canvas/autosave-delay';
+
+describe('resolveInkAutosaveDelayMs', () => {
+	test('keeps the short quiet period on desktop', () => {
+		expect(resolveInkAutosaveDelayMs({}, 500, 2000)).toBe(500);
+	});
+
+	test.each([
+		{ isMobile: true },
+		{ isMobileApp: true },
+		{ isIosApp: true },
+	])('uses the longer quiet period for mobile platform flag %#', (platform) => {
+		expect(resolveInkAutosaveDelayMs(platform, 500, 2000)).toBe(2000);
+	});
+});

--- a/tests/ink-canvas/rendered-stroke-cache.test.ts
+++ b/tests/ink-canvas/rendered-stroke-cache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from '@jest/globals';
+import { getRenderedStrokeData } from 'src/ink-canvas/rendered-stroke-cache';
+import type { InkStroke } from 'src/ink-canvas/types';
+import { DEFAULT_STROKE_STYLE } from 'src/ink-canvas/types';
+
+const stroke: InkStroke = {
+	id: 'cached-stroke',
+	points: [[0, 0, 0.5], [20, 10, 0.6], [40, 5, 0.5]],
+	style: { ...DEFAULT_STROKE_STYLE },
+	offset: { x: 0, y: 0 },
+};
+
+describe('rendered stroke cache', () => {
+	test('reuses the rendered outline for the same immutable stroke', () => {
+		const first = getRenderedStrokeData(stroke);
+		const second = getRenderedStrokeData(stroke);
+
+		expect(second).toBe(first);
+		expect(first.pathD).not.toBe('');
+		expect(first.bounds.maxX).toBeGreaterThan(first.bounds.minX);
+	});
+
+	test('keeps translation outside cached path geometry', () => {
+		const movedStroke = { ...stroke, offset: { x: 100, y: 200 } };
+		const original = getRenderedStrokeData(stroke);
+		const moved = getRenderedStrokeData(movedStroke);
+
+		expect(moved.pathD).toBe(original.pathD);
+		expect(moved.bounds).toEqual(original.bounds);
+	});
+});

--- a/tests/ink-canvas/stroke-store.test.ts
+++ b/tests/ink-canvas/stroke-store.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from '@jest/globals';
+import { StrokeStore, type StrokeStoreChange } from 'src/ink-canvas/stroke-store';
+import type { InkStroke } from 'src/ink-canvas/types';
+import { DEFAULT_STROKE_STYLE } from 'src/ink-canvas/types';
+
+function makeStroke(id: string): InkStroke {
+	return {
+		id,
+		points: [[0, 0, 0.5], [10, 10, 0.5]],
+		style: { ...DEFAULT_STROKE_STYLE },
+		offset: { x: 0, y: 0 },
+	};
+}
+
+describe('StrokeStore change notifications', () => {
+	test('identifies only the strokes touched by incremental mutations', () => {
+		const store = new StrokeStore();
+		const changes: StrokeStoreChange[] = [];
+		store.subscribe((change) => changes.push(change));
+
+		store.add(makeStroke('a'));
+		store.addMany([makeStroke('b'), makeStroke('c')]);
+		store.updateOffsets(new Map([['b', { x: 5, y: 8 }]]));
+		store.remove(['a']);
+
+		expect(changes).toEqual([
+			{ type: 'add', ids: ['a'] },
+			{ type: 'addMany', ids: ['b', 'c'] },
+			{ type: 'updateOffsets', ids: ['b'] },
+			{ type: 'remove', ids: ['a'] },
+		]);
+	});
+
+	test('marks whole-store replacement mutations explicitly', () => {
+		const store = new StrokeStore();
+		const changes: StrokeStoreChange[] = [];
+		store.subscribe((change) => changes.push(change));
+
+		store.replaceAll([makeStroke('a')]);
+		store.clear();
+
+		expect(changes).toEqual([
+			{ type: 'replaceAll', ids: [] },
+			{ type: 'clear', ids: [] },
+		]);
+	});
+});

--- a/tests/ink-canvas/svg-export.test.ts
+++ b/tests/ink-canvas/svg-export.test.ts
@@ -42,6 +42,12 @@ describe('svg-export', () => {
 		expect(svg).not.toContain('fill="currentColor"');
 	});
 
+	test('renderStrokesToSvg uses finite fallback bounds for an empty canvas', () => {
+		const svg = renderStrokesToSvg([], emptySnapshot);
+		expect(svg).toContain('viewBox="0 0 1 1"');
+		expect(svg).not.toMatch(/Infinity|NaN/);
+	});
+
 	test('renderStrokesToSvg wraps offset strokes in translate group', () => {
 		const offsetStroke: InkStroke = {
 			...sampleStroke,

--- a/tests/logic/utils/ink-file-has-strokes.test.ts
+++ b/tests/logic/utils/ink-file-has-strokes.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_STROKE_STYLE } from 'src/ink-canvas/types';
 import {
 	getInkStrokesFromSvg,
 	inkFileHasStrokes,
+	sniffInkCanvasHasStrokes,
 	showLockedChrome,
 } from 'src/logic/utils/ink-file-has-strokes';
 
@@ -102,6 +103,23 @@ describe('inkFileHasStrokes', () => {
 			offset: { x: 0, y: 0 },
 		};
 		expect(inkFileHasStrokes(makeInkCanvasSvg([stroke]))).toBe(true);
+	});
+});
+
+describe('sniffInkCanvasHasStrokes', () => {
+	test('detects empty and populated current-format stroke arrays without parsing the SVG', () => {
+		expect(sniffInkCanvasHasStrokes(makeInkCanvasSvg([]))).toBe(false);
+		expect(sniffInkCanvasHasStrokes(makeInkCanvasSvg([{}]))).toBe(true);
+	});
+
+	test('allows whitespace before the first array item', () => {
+		const svg = makeInkCanvasSvg([]).replace('"strokes":[]', '"strokes":[ \n\t]');
+		expect(sniffInkCanvasHasStrokes(svg)).toBe(false);
+	});
+
+	test('falls back for legacy or malformed metadata', () => {
+		expect(sniffInkCanvasHasStrokes(makeTldrawSvg({}))).toBeNull();
+		expect(sniffInkCanvasHasStrokes('<svg><ink-canvas>{"strokes":[')).toBeNull();
 	});
 });
 


### PR DESCRIPTION
## Summary
- Same large-canvas performance and dark Reading-mode / embed-overhead work originally from [#198](https://github.com/daledesilva/obsidian_ink/pull/198) / [#203](https://github.com/daledesilva/obsidian_ink/pull/203), without the PDF-export commits.
- Caches rendered stroke geometry, simplifies ink-canvas SVG metadata saves, pauses autosave during active pen input, and uses a longer mobile quiet period.
- **Original author:** [@Llewellyn500](https://github.com/Llewellyn500) (Llewellyn Adonteng Paintsil). Commit authorship is preserved.

Related to #84. Targets `release_0.5` (re-opened after #203 was accidentally merged to `main` and reverted).

## Test plan
- [ ] Write for a long session on a large writing attachment (PC + iPad if available) and confirm lag no longer builds as before
- [ ] Confirm autosave still persists after pen lifts
- [ ] Spot-check dark Reading mode Ink previews
- [ ] `npm run test:unit -- --runInBand`
- [ ] `npm run build`


Made with [Cursor](https://cursor.com)